### PR TITLE
ZincRepo now returns ListenableFutures.

### DIFF
--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
@@ -1,5 +1,6 @@
 package com.mindsnacks.zinc.classes;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.mindsnacks.zinc.classes.data.*;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
@@ -74,7 +75,7 @@ public class ZincRepo implements Repo {
      * has not been scheduled yet and the repo is paused.
      */
     @Override
-    public Future<ZincBundle> getBundle(final BundleID bundleID) {
+    public ListenableFuture<ZincBundle> getBundle(final BundleID bundleID) {
         try {
             return mQueue.get(mBundles.get(bundleID));
         } catch (PriorityJobQueue.JobNotFoundException e) {

--- a/src/main/java/com/mindsnacks/zinc/classes/downloads/PriorityJobQueue.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/downloads/PriorityJobQueue.java
@@ -124,7 +124,7 @@ public class PriorityJobQueue<Input, Output> {
         }
     }
 
-    public Future<Output> get(final Input element) throws JobNotFoundException {
+    public ListenableFuture<Output> get(final Input element) throws JobNotFoundException {
         checkServiceIsRunning(true, "Service should be running");
 
         if (mAddedElements.contains(element)) {
@@ -180,7 +180,7 @@ public class PriorityJobQueue<Input, Output> {
         return mExecutorService.submit(mDataProcessor.process(element));
     }
 
-    private Future<Output> waitForFuture(final Input element) {
+    private ListenableFuture<Output> waitForFuture(final Input element) {
         return Futures.dereference(mFuturesExecutorService.submit(new Callable<ListenableFuture<Output>>() {
             @Override
             public ListenableFuture<Output> call() throws Exception {

--- a/src/test/java/com/mindsnacks/zinc/repo/ZincRepoJobsTest.java
+++ b/src/test/java/com/mindsnacks/zinc/repo/ZincRepoJobsTest.java
@@ -1,5 +1,6 @@
 package com.mindsnacks.zinc.repo;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.mindsnacks.zinc.classes.ZincRepoIndexWriter;
 import com.mindsnacks.zinc.classes.data.*;
 import org.junit.Before;
@@ -133,7 +134,7 @@ public class ZincRepoJobsTest extends ZincRepoBaseTest {
     public void getBundleWithIDReturnsExistingPromise() throws Exception {
         final BundleID bundleID = new BundleID(mCatalogID, "swell");
         final String distribution = "develop";
-        final Future<ZincBundle> expectedResult = mock(Future.class);
+        final ListenableFuture<ZincBundle> expectedResult = mock(ListenableFuture.class);
 
         setUpIndexWithTrackedBundleID(bundleID, distribution);
         mockCloneBundle(bundleID, expectedResult);
@@ -156,7 +157,7 @@ public class ZincRepoJobsTest extends ZincRepoBaseTest {
     }
 
     @SuppressWarnings("unchecked")
-    private void mockCloneBundle(final BundleID bundleID, final Future<ZincBundle> expectedResult) {
+    private void mockCloneBundle(final BundleID bundleID, final ListenableFuture<ZincBundle> expectedResult) {
         when(mQueue.get(argThat(new ArgumentMatcher<ZincCloneBundleRequest>() {
             @Override
             public boolean matches(final Object o) {


### PR DESCRIPTION
`PriorityJobQueue` was already creating `ListenableFuture`s, so this simply returns them as such.
