### PR TITLE
ZincCloneBundleJob: fixed bug that would prevent a bundle to be downloaded if

### DIFF
--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
@@ -34,7 +34,7 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
 
         final File localBundleFolder = getLocalBundleFolder();
 
-        if (!localBundleFolder.exists()) { // TODO: extract this logic as a first step to implement bundle verification
+        if (shouldDownloadBundle(localBundleFolder)) {
             createFolder(localBundleFolder);
 
             final ZincManifest manifest = getManifest();
@@ -56,6 +56,11 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
 
             return createZincBundle(localBundleFolder);
         }
+    }
+
+    private boolean shouldDownloadBundle(final File localBundleFolder) {
+        // TODO: extract this logic as a first step to implement bundle verification
+        return (!localBundleFolder.exists() || localBundleFolder.listFiles().length == 0);
     }
 
     private void createFolder(final File folder) {

--- a/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
+++ b/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
@@ -4,6 +4,7 @@ import com.mindsnacks.zinc.classes.ZincJobFactory;
 import com.mindsnacks.zinc.classes.data.*;
 import com.mindsnacks.zinc.classes.jobs.ZincCloneBundleJob;
 import com.mindsnacks.zinc.utils.TestFactory;
+import com.mindsnacks.zinc.utils.TestUtils;
 import com.mindsnacks.zinc.utils.ZincBaseTest;
 import org.junit.Before;
 import org.junit.Rule;
@@ -115,8 +116,17 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
     }
 
     @Test
-    public void bundleIsNotDownloadedifItAlreadyExists() throws Exception {
+    public void bundleIDownloadedIfItAlreadyExistsButItsEmpty() throws Exception {
         createExpectedResultDirectory();
+
+        run();
+
+        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
+    }
+
+    @Test
+    public void bundleIsNotDownloadedIfItAlreadyExists() throws Exception {
+        createExpectedResultDirectoryWithFiles();
 
         run();
 
@@ -126,7 +136,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
 
     @Test
     public void bundleIsReturnedIfItAlreadyExists() throws Exception {
-        verifyResult(createExpectedResultDirectory(), run());
+        verifyResult(createExpectedResultDirectoryWithFiles(), run());
     }
 
     @Test
@@ -195,6 +205,14 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
         assert file.exists();
 
         return file;
+    }
+
+    private File createExpectedResultDirectoryWithFiles() throws IOException {
+        final File folder = createExpectedResultDirectory();
+
+        TestUtils.createRandomFileInFolder(folder);
+
+        return folder;
     }
 
     private File expectedResultDirectory() {

--- a/src/test/java/com/mindsnacks/zinc/utils/TestUtils.java
+++ b/src/test/java/com/mindsnacks/zinc/utils/TestUtils.java
@@ -48,4 +48,10 @@ public class TestUtils {
             writer.close();
         }
     }
+
+    public static void createRandomFileInFolder(final File folder) throws IOException {
+        TestUtils.writeToFile(
+                new File(folder, TestFactory.randomString()),
+                TestFactory.randomString());
+    }
 }


### PR DESCRIPTION
the folder was there but it was empty

Note: this partially breaks compatibility with empty bundles (which we don't
need anymore anyway), but only in the sense that it makes them be downloaded
every time.
