### PR TITLE
[FINAL] Feature/fix corrupt downloads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: java
 jdk:
   - oraclejdk7
   - openjdk7
-  - openjdk6
 notifications:
   email: false
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>2.3.2</version>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.7</source>
+                        <target>1.7</target>
                         <compilerArgument />
                     </configuration>
                 </plugin>

--- a/src/main/java/com/mindsnacks/zinc/classes/Repo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/Repo.java
@@ -28,5 +28,5 @@ public interface Repo {
     /**
      * Must be called before calling start.
      */
-    void clearCachedCatalogs();
+    void clearCachedCatalogsAndManifests();
 }

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincBundleDownloader.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincBundleDownloader.java
@@ -3,7 +3,8 @@ package com.mindsnacks.zinc.classes;
 import com.mindsnacks.zinc.classes.data.ZincBundle;
 import com.mindsnacks.zinc.classes.data.ZincCatalogsCache;
 import com.mindsnacks.zinc.classes.data.ZincCloneBundleRequest;
-import com.mindsnacks.zinc.classes.data.ZincManifestCache;
+import com.mindsnacks.zinc.classes.data.ZincManifests;
+import com.mindsnacks.zinc.classes.data.ZincManifestsCache;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
 
 import java.util.concurrent.Callable;
@@ -15,14 +16,18 @@ import java.util.concurrent.Callable;
 public class ZincBundleDownloader implements PriorityJobQueue.DataProcessor<ZincCloneBundleRequest, ZincBundle> {
     private final ZincJobFactory mJobFactory;
     private final ZincCatalogsCache mCatalogs;
+    private final ZincManifestsCache mManifests;
 
-    public ZincBundleDownloader(final ZincJobFactory jobFactory, final ZincCatalogsCache catalogs) {
+    public ZincBundleDownloader(final ZincJobFactory jobFactory,
+                                final ZincCatalogsCache catalogs,
+                                final ZincManifestsCache manifests) {
         mJobFactory = jobFactory;
         mCatalogs = catalogs;
+        mManifests = manifests;
     }
 
     @Override
     public Callable<ZincBundle> process(final ZincCloneBundleRequest request) {
-        return mJobFactory.cloneBundle(request, mCatalogs.getCatalog(request.getSourceURL()));
+        return mJobFactory.cloneBundle(request, mCatalogs.getCatalog(request.getSourceURL()), mManifests);
     }
 }

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincBundleDownloader.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincBundleDownloader.java
@@ -3,6 +3,7 @@ package com.mindsnacks.zinc.classes;
 import com.mindsnacks.zinc.classes.data.ZincBundle;
 import com.mindsnacks.zinc.classes.data.ZincCatalogsCache;
 import com.mindsnacks.zinc.classes.data.ZincCloneBundleRequest;
+import com.mindsnacks.zinc.classes.data.ZincManifestCache;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
 
 import java.util.concurrent.Callable;

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincJobFactory.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincJobFactory.java
@@ -15,7 +15,7 @@ public interface ZincJobFactory {
     Callable<ZincCatalog> downloadCatalog(SourceURL sourceURL);
     Callable<ZincManifest> downloadManifest(SourceURL sourceURL, String bundleName, int version);
     Callable<File> downloadArchive(URL url, File root, String child, boolean override);
-    Callable<ZincBundle> cloneBundle(ZincCloneBundleRequest request, Future<ZincCatalog> catalogFuture);
+    Callable<ZincBundle> cloneBundle(ZincCloneBundleRequest request, Future<ZincCatalog> catalogFuture, ZincManifestsCache manifests);
     Callable<ZincBundle> downloadBundle(ZincCloneBundleRequest request, Future<ZincCatalog> catalogFuture);
     Callable<File> downloadFile(URL url, File root, File repoFolder, String child, boolean override, String expectedHash);
     Callable<ZincBundle> unarchiveBundle(ZincBundle downloadedBundle, ZincCloneBundleRequest request, ZincManifest manifest);

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
@@ -6,7 +6,7 @@ import com.mindsnacks.zinc.classes.data.SourceURL;
 import com.mindsnacks.zinc.classes.data.ZincBundle;
 import com.mindsnacks.zinc.classes.data.ZincCatalogsCache;
 import com.mindsnacks.zinc.classes.data.ZincCloneBundleRequest;
-import com.mindsnacks.zinc.classes.data.ZincManifestCache;
+import com.mindsnacks.zinc.classes.data.ZincManifestsCache;
 import com.mindsnacks.zinc.classes.data.ZincRepoIndex;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
@@ -26,6 +26,7 @@ public class ZincRepo implements Repo {
     private final PriorityJobQueue<ZincCloneBundleRequest, ZincBundle> mQueue;
     private final ZincRepoIndexWriter mIndexWriter;
     private final ZincCatalogsCache mCatalogsCache;
+    private final ZincManifestsCache mManifestsCache;
     private final String mFlavorName;
 
     private final File mRoot;
@@ -40,9 +41,11 @@ public class ZincRepo implements Repo {
                     final URI root,
                     final ZincRepoIndexWriter repoIndexWriter,
                     final ZincCatalogsCache catalogsCache,
+                    final ZincManifestsCache manifestsCache,
                     final String flavorName) {
         mQueue = queue;
         mCatalogsCache = catalogsCache;
+        mManifestsCache = manifestsCache;
         mFlavorName = flavorName;
         mRoot = new File(root);
         mIndexWriter = repoIndexWriter;
@@ -107,8 +110,9 @@ public class ZincRepo implements Repo {
     }
 
     @Override
-    public void clearCachedCatalogs() {
+    public void clearCachedCatalogsAndManifests() {
         mCatalogsCache.clearCachedCatalogs();
+        mManifestsCache.clearCachedManifests();
     }
 
     @Override

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
@@ -6,6 +6,7 @@ import com.mindsnacks.zinc.classes.data.SourceURL;
 import com.mindsnacks.zinc.classes.data.ZincBundle;
 import com.mindsnacks.zinc.classes.data.ZincCatalogsCache;
 import com.mindsnacks.zinc.classes.data.ZincCloneBundleRequest;
+import com.mindsnacks.zinc.classes.data.ZincManifestCache;
 import com.mindsnacks.zinc.classes.data.ZincRepoIndex;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepoFactory.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepoFactory.java
@@ -37,6 +37,7 @@ public final class ZincRepoFactory {
         final ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(CATALOG_DOWNLOAD_THREAD_POOL_SIZE, threadFactory);
 
         final ZincCatalogsCache catalogs = createCatalogCache(jobFactory, root, gson, indexWriter.getIndex(), executorService);
+        final ZincManifestCache manifests = createManifestCache(jobFactory, root, gson, executorService);
 
         final PriorityJobQueue<ZincCloneBundleRequest, ZincBundle> queue = createQueue(
                 bundleCloneConcurrency,
@@ -58,6 +59,17 @@ public final class ZincRepoFactory {
                     executorService,
                     executorService,
                     new Timer(ZincCatalogs.class.getSimpleName(), true));
+    }
+
+    private ZincManifestCache createManifestCache(final ZincJobFactory jobFactory,
+                                                  final File root,
+                                                  final Gson gson,
+                                                  final ScheduledExecutorService executorService) {
+        return new ZincManifests(root,
+                                 new FileHelper(gson, new HashUtil()),
+                                 jobFactory,
+                                 executorService,
+                                 executorService);
     }
 
     private Gson createGson() {

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepoFactory.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepoFactory.java
@@ -37,14 +37,14 @@ public final class ZincRepoFactory {
         final ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(CATALOG_DOWNLOAD_THREAD_POOL_SIZE, threadFactory);
 
         final ZincCatalogsCache catalogs = createCatalogCache(jobFactory, root, gson, indexWriter.getIndex(), executorService);
-        final ZincManifestCache manifests = createManifestCache(jobFactory, root, gson, executorService);
+        final ZincManifestsCache manifests = createManifestCache(jobFactory, root, gson, executorService);
 
         final PriorityJobQueue<ZincCloneBundleRequest, ZincBundle> queue = createQueue(
                 bundleCloneConcurrency,
-                new ZincBundleDownloader(jobFactory, catalogs),
+                new ZincBundleDownloader(jobFactory, catalogs, manifests),
                 createPriorityCalculator(priorityCalculator));
 
-        return new ZincRepo(queue, root.toURI(), indexWriter, catalogs, flavorName);
+        return new ZincRepo(queue, root.toURI(), indexWriter, catalogs, manifests, flavorName);
     }
 
     private ZincCatalogsCache createCatalogCache(final ZincJobFactory jobFactory,
@@ -61,7 +61,7 @@ public final class ZincRepoFactory {
                     new Timer(ZincCatalogs.class.getSimpleName(), true));
     }
 
-    private ZincManifestCache createManifestCache(final ZincJobFactory jobFactory,
+    private ZincManifestsCache createManifestCache(final ZincJobFactory jobFactory,
                                                   final File root,
                                                   final Gson gson,
                                                   final ScheduledExecutorService executorService) {

--- a/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
@@ -39,7 +39,7 @@ public class PathHelper {
     }
 
     public static String getLocalManifestFilePath(final String catalogID, final String manifestID) {
-        return String.format("%s/%s/%s.%s", getManifestsFolder(), catalogID, manifestID, MANIFESTS_FORMAT);
+        return String.format("%s%s/%s.%s", getManifestsFolder(), catalogID, manifestID, MANIFESTS_FORMAT);
     }
 
     public static String getCatalogsFolder() {

--- a/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
@@ -11,8 +11,11 @@ public class PathHelper {
     private static final String TEMPORARY_BUNDLES_FOLDER = "temp";
 
     private static final String CATALOGS_FOLDER = "catalogs";
-
     private static final String CATALOGS_FORMAT = "json";
+
+    private static final String MANIFESTS_FOLDER = "manifests";
+    private static final String MANIFESTS_FORMAT = "json";
+
     public static final String FLAVOR_SEPARATOR = "~";
 
     public static String getLocalDownloadFolder(final BundleID bundleID, final int version, final String flavorName) {
@@ -35,7 +38,16 @@ public class PathHelper {
         return String.format("%s%s.%s", getCatalogsFolder(), catalogID, CATALOGS_FORMAT);
     }
 
+    public static String getLocalManifestFilePath(final String manifestID) {
+        return String.format("%s%s.%s", getManifestsFolder(), manifestID, MANIFESTS_FORMAT);
+    }
+
     public static String getCatalogsFolder() {
         return String.format("%s/", CATALOGS_FOLDER);
     }
+
+    public static String getManifestsFolder() {
+        return String.format("%s/", MANIFESTS_FOLDER);
+    }
+
 }

--- a/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
@@ -38,8 +38,8 @@ public class PathHelper {
         return String.format("%s%s.%s", getCatalogsFolder(), catalogID, CATALOGS_FORMAT);
     }
 
-    public static String getLocalManifestFilePath(final String manifestID) {
-        return String.format("%s%s.%s", getManifestsFolder(), manifestID, MANIFESTS_FORMAT);
+    public static String getLocalManifestFilePath(final String catalogID, final String manifestID) {
+        return String.format("%s/%s/%s.%s", getManifestsFolder(), catalogID, manifestID, MANIFESTS_FORMAT);
     }
 
     public static String getCatalogsFolder() {

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincCatalogs.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincCatalogs.java
@@ -1,6 +1,7 @@
 package com.mindsnacks.zinc.classes.data;
 
 import com.google.common.util.concurrent.*;
+import com.google.gson.JsonSyntaxException;
 import com.mindsnacks.zinc.classes.ZincJobFactory;
 import com.mindsnacks.zinc.classes.ZincLogging;
 import com.mindsnacks.zinc.classes.fileutils.FileHelper;
@@ -65,7 +66,7 @@ public class ZincCatalogs implements ZincCatalogsCache {
 
             try {
                 result = getPersistedCatalog(sourceURL, catalogFile);
-            } catch (final FileNotFoundException e) {
+            } catch (final FileNotFoundException | JsonSyntaxException e) {
                 result = downloadCatalog(sourceURL, catalogFile);
             }
 
@@ -173,6 +174,10 @@ public class ZincCatalogs implements ZincCatalogsCache {
     }
 
     private ZincCatalog readCatalogFile(final File catalogFile) throws FileNotFoundException {
+        if (catalogFile.length() == 0) {
+            throw new FileNotFoundException("Catalog file is empty");
+        }
+
         return mFileHelper.readJSON(catalogFile, ZincCatalog.class);
     }
 

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincCatalogs.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincCatalogs.java
@@ -169,7 +169,7 @@ public class ZincCatalogs implements ZincCatalogsCache {
         return new File(mRoot, PathHelper.getCatalogsFolder());
     }
 
-    private File getCatalogFile(final SourceURL sourceURL) {
+    public File getCatalogFile(final SourceURL sourceURL) {
         return new File(mRoot, PathHelper.getLocalCatalogFilePath(sourceURL.getCatalogID()));
     }
 

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifestCache.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifestCache.java
@@ -1,0 +1,13 @@
+package com.mindsnacks.zinc.classes.data;
+import java.util.concurrent.Future;
+
+/**
+ * Created by Miguel Carranza on 6/26/15.
+ */
+public interface ZincManifestCache {
+    boolean clearCachedManifests();
+
+    Future<ZincManifest> getManifest(final SourceURL sourceURL,
+                                     final String bundleName,
+                                     final int version);
+}

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -129,7 +129,7 @@ public class ZincManifests implements ZincManifestsCache {
         return new File(mRoot, PathHelper.getManifestsFolder());
     }
 
-    private File getManifestFile(final String catalogID, final String manifestID) {
+    public File getManifestFile(final String catalogID, final String manifestID) {
         return new File(mRoot, PathHelper.getLocalManifestFilePath(catalogID, manifestID));
     }
 

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -134,7 +134,7 @@ public class ZincManifests implements ZincManifestsCache {
 
     private String getManifestID(final String bundleName,
                                  final int version) {
-        return String.format("%s_%d", bundleName, version);
+        return String.format("%s-%d", bundleName, version);
     }
 
     private ZincManifest readManifestFile(final File manifestFile) throws FileNotFoundException {

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -51,7 +51,7 @@ public class ZincManifests implements ZincManifestsCache {
         if (!mFutures.containsKey(manifestID)) {
             ListenableFuture<ZincManifest> result;
 
-            final File manifestFile = getManifestFile(manifestID);
+            final File manifestFile = getManifestFile(sourceURL.getCatalogID(), manifestID);
 
             try {
                 result = getPersistedManifest(manifestID, manifestFile);
@@ -128,8 +128,8 @@ public class ZincManifests implements ZincManifestsCache {
         return new File(mRoot, PathHelper.getManifestsFolder());
     }
 
-    private File getManifestFile(final String manifestID) {
-        return new File(mRoot, PathHelper.getLocalManifestFilePath(manifestID));
+    private File getManifestFile(final String catalogID, final String manifestID) {
+        return new File(mRoot, PathHelper.getLocalManifestFilePath(catalogID, manifestID));
     }
 
     private String getManifestID(final String bundleName,

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -57,9 +57,9 @@ public class ZincManifests implements ZincManifestsCache {
                 result = getPersistedManifest(manifestID, manifestFile);
             } catch (final FileNotFoundException e) {
                 result = downloadManifest(sourceURL,
-                        bundleName,
-                        version,
-                        manifestFile);
+                                          bundleName,
+                                          version,
+                                          manifestFile);
             }
 
             cacheFuture(manifestID, result);

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -1,6 +1,7 @@
 package com.mindsnacks.zinc.classes.data;
 
 import com.google.common.util.concurrent.*;
+import com.google.gson.JsonSyntaxException;
 import com.mindsnacks.zinc.classes.ZincJobFactory;
 import com.mindsnacks.zinc.classes.ZincLogging;
 import com.mindsnacks.zinc.classes.fileutils.FileHelper;
@@ -55,7 +56,7 @@ public class ZincManifests implements ZincManifestsCache {
 
             try {
                 result = getPersistedManifest(manifestID, manifestFile);
-            } catch (final FileNotFoundException e) {
+            } catch (final FileNotFoundException | JsonSyntaxException e) {
                 result = downloadManifest(sourceURL,
                                           bundleName,
                                           version,
@@ -138,6 +139,10 @@ public class ZincManifests implements ZincManifestsCache {
     }
 
     private ZincManifest readManifestFile(final File manifestFile) throws FileNotFoundException {
+        if (manifestFile.length() == 0) {
+            throw new FileNotFoundException("Manifest file is empty");
+        }
+
         return mFileHelper.readJSON(manifestFile, ZincManifest.class);
     }
 

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -15,7 +15,7 @@ import java.util.concurrent.Future;
 /**
  * Created by Miguel Carranza on 6/26/15.
  */
-public class ZincManifests implements ZincManifestCache {
+public class ZincManifests implements ZincManifestsCache {
     private final File mRoot;
     private final FileHelper mFileHelper;
 
@@ -57,9 +57,9 @@ public class ZincManifests implements ZincManifestCache {
                 result = getPersistedManifest(manifestID, manifestFile);
             } catch (final FileNotFoundException e) {
                 result = downloadManifest(sourceURL,
-                                          bundleName,
-                                          version,
-                                          manifestFile);
+                        bundleName,
+                        version,
+                        manifestFile);
             }
 
             cacheFuture(manifestID, result);

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -1,0 +1,147 @@
+package com.mindsnacks.zinc.classes.data;
+
+import com.google.common.util.concurrent.*;
+import com.mindsnacks.zinc.classes.ZincJobFactory;
+import com.mindsnacks.zinc.classes.ZincLogging;
+import com.mindsnacks.zinc.classes.fileutils.FileHelper;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+/**
+ * Created by Miguel Carranza on 6/26/15.
+ */
+public class ZincManifests implements ZincManifestCache {
+    private final File mRoot;
+    private final FileHelper mFileHelper;
+
+    private final ZincJobFactory mJobFactory;
+    private final ListeningExecutorService mDownloadExecutorService;
+    private final ExecutorService mPersistenceExecutorService;
+
+    private final Map<String, ListenableFuture<ZincManifest>> mFutures = new HashMap<String, ListenableFuture<ZincManifest>>();
+
+    public ZincManifests(final File root,
+                         final FileHelper fileHelper,
+                         final ZincJobFactory jobFactory,
+                         final ExecutorService downloadExecutorService,
+                         final ExecutorService persistenceExecutorService) {
+        mRoot = root;
+        mFileHelper = fileHelper;
+        mJobFactory = jobFactory;
+        mDownloadExecutorService = MoreExecutors.listeningDecorator(downloadExecutorService);
+        mPersistenceExecutorService = persistenceExecutorService;
+    }
+
+    @Override
+    public boolean clearCachedManifests() {
+        return mFileHelper.emptyDirectory(getManifestsFolder());
+    }
+
+    @Override
+    public synchronized Future<ZincManifest> getManifest(final SourceURL sourceURL,
+                                                         final String bundleName,
+                                                         final int version) {
+        String manifestID = getManifestID(bundleName, version);
+
+        if (!mFutures.containsKey(manifestID)) {
+            ListenableFuture<ZincManifest> result;
+
+            final File manifestFile = getManifestFile(manifestID);
+
+            try {
+                result = getPersistedManifest(manifestID, manifestFile);
+            } catch (final FileNotFoundException e) {
+                result = downloadManifest(sourceURL,
+                                          bundleName,
+                                          version,
+                                          manifestFile);
+            }
+
+            cacheFuture(manifestID, result);
+        }
+        return mFutures.get(manifestID);
+    }
+
+    private synchronized SettableFuture<ZincManifest> getPersistedManifest(final String manifestID,
+                                                                           final File manifestFile) throws FileNotFoundException {
+        final ZincManifest zincManifest = readManifestFile(manifestFile);
+
+        final SettableFuture<ZincManifest> future = SettableFuture.create();
+        future.set(zincManifest);
+
+        logMessage(manifestID, "Returning persisted manifest");
+
+        return future;
+    }
+
+    private synchronized ListenableFuture<ZincManifest> downloadManifest(final SourceURL sourceURL,
+                                                                         final String bundleName,
+                                                                         final int version,
+                                                                         final File manifestFile) {
+        final String manifestID = getManifestID(bundleName, version);
+        final ListenableFuture<ZincManifest> originalFuture = mFutures.get(manifestID);
+        final ListenableFuture<ZincManifest> result = mDownloadExecutorService.submit(mJobFactory.downloadManifest(sourceURL, bundleName, version));
+
+        Futures.addCallback(result, new FutureCallback<ZincManifest>() {
+            @Override public void onSuccess(final ZincManifest result) {
+                persitManifest(result, manifestFile);
+            }
+
+            @Override public void onFailure(final Throwable downloadFailed) {
+                logMessage(manifestID, "Failed to download");
+
+                if (originalFuture != null) {
+                    cacheFuture(manifestID, originalFuture);
+                } else {
+                    removeFuture(manifestID);
+                }
+            }
+        }, mPersistenceExecutorService);
+
+        return result;
+    }
+
+    private synchronized void persitManifest(final ZincManifest result, final File manifestFile) {
+        try {
+            logMessage(result.getIdentifier(), "Persisting manifest to disk: " + result.getIdentifier());
+
+            mFileHelper.writeObject(manifestFile, result, ZincManifest.class);
+        } catch (final IOException e) {
+            logMessage(result.getIdentifier(), "Error persisting manifest to disk: " + e);
+        }
+    }
+
+    private synchronized void cacheFuture(final String manifestID, final ListenableFuture<ZincManifest> future) {
+        mFutures.put(manifestID, future);
+    }
+
+    private synchronized void removeFuture(final String manifestID) {
+        mFutures.remove(manifestID);
+    }
+
+    private File getManifestsFolder() {
+        return new File(mRoot, PathHelper.getManifestsFolder());
+    }
+
+    private File getManifestFile(final String manifestID) {
+        return new File(mRoot, PathHelper.getLocalManifestFilePath(manifestID));
+    }
+
+    private String getManifestID(final String bundleName,
+                                 final int version) {
+        return String.format("%s_%d", bundleName, version);
+    }
+
+    private ZincManifest readManifestFile(final File manifestFile) throws FileNotFoundException {
+        return mFileHelper.readJSON(manifestFile, ZincManifest.class);
+    }
+
+    private void logMessage(final String manifestID, final String message) {
+        ZincLogging.log(getClass().getSimpleName() + " (" + manifestID + ")", message);
+    }
+}

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifestsCache.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifestsCache.java
@@ -4,7 +4,7 @@ import java.util.concurrent.Future;
 /**
  * Created by Miguel Carranza on 6/26/15.
  */
-public interface ZincManifestCache {
+public interface ZincManifestsCache {
     boolean clearCachedManifests();
 
     Future<ZincManifest> getManifest(final SourceURL sourceURL,

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
@@ -50,9 +50,7 @@ public class BundleIntegrityVerifier {
             in.close();
             digestStream.validate(expectedHash);
             isValid = true;
-        } catch (FileNotFoundException e) {
-        } catch (ValidatingDigestInputStream.HashFailedException e) {
-        } catch (IOException e) {}
+        } catch (ValidatingDigestInputStream.HashFailedException|IOException e) {}
 
         return isValid;
     }

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
@@ -3,28 +3,36 @@ package com.mindsnacks.zinc.classes.fileutils;
 import com.mindsnacks.zinc.classes.data.ZincManifest;
 import com.pegasus.data.accounts.PegasusAccountFieldValidator;
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
  * Created by Miguel Carranza on 6/28/15.
  */
 public class BundleIntegrityVerifier {
+    private static final int BUFFER_SIZE = 8192;
+
     public static boolean isLocalBundleValid(final File localBundleFolder,
                                              final ZincManifest manifest,
                                              final String flavorName) {
         boolean isValid = true;
         final Map<String, ZincManifest.FileInfo> files = manifest.getFilesWithFlavor(flavorName);
+        final Iterator<String> it = files.keySet().iterator();
 
-        for (final Map.Entry<String, ZincManifest.FileInfo> entry : files.entrySet()) {
-            final String fileName = entry.getKey();
-            final ZincManifest.FileInfo fileInfo = entry.getValue();
-            final File localFile = new File(localBundleFolder, fileName);
+        while(it.hasNext() && isValid) {
+            final String fileName = it.next();
+            final ZincManifest.FileInfo fileInfo = files.get(fileName);
             final String expectedHash = fileInfo.getHash();
-            isValid = isValid && isLocalFileValid(localFile, expectedHash);
+            final File localFile = new File(localBundleFolder, fileName);
+
+            isValid &= isLocalFileValid(localFile, expectedHash);
         }
 
         return isValid;
@@ -37,11 +45,20 @@ public class BundleIntegrityVerifier {
 
         try {
             final ValidatingDigestInputStream digestStream = hashUtil.wrapInputStreamWithDigest(new FileInputStream(localFile));
+            final InputStream in = new BufferedInputStream(digestStream);
+            readInputStream(in);
+            in.close();
             digestStream.validate(expectedHash);
             isValid = true;
         } catch (FileNotFoundException e) {
-        } catch (ValidatingDigestInputStream.HashFailedException e) {}
+        } catch (ValidatingDigestInputStream.HashFailedException e) {
+        } catch (IOException e) {}
 
         return isValid;
+    }
+
+    private static void readInputStream(final InputStream stream) throws IOException {
+        final byte[] bytes = new byte[BUFFER_SIZE];
+        for (int read = 0; (read = stream.read(bytes, 0, BUFFER_SIZE)) !=-1;) {}
     }
 }

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
@@ -1,8 +1,6 @@
 package com.mindsnacks.zinc.classes.fileutils;
 
 import com.mindsnacks.zinc.classes.data.ZincManifest;
-import com.pegasus.data.accounts.PegasusAccountFieldValidator;
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
@@ -50,7 +50,7 @@ public class BundleIntegrityVerifier {
             in.close();
             digestStream.validate(expectedHash);
             isValid = true;
-        } catch (ValidatingDigestInputStream.HashFailedException|IOException e) {}
+        } catch (ValidatingDigestInputStream.HashFailedException | IOException e) {}
 
         return isValid;
     }

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
@@ -1,0 +1,47 @@
+package com.mindsnacks.zinc.classes.fileutils;
+
+import com.mindsnacks.zinc.classes.data.ZincManifest;
+import com.pegasus.data.accounts.PegasusAccountFieldValidator;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.util.Map;
+
+/**
+ * Created by Miguel Carranza on 6/28/15.
+ */
+public class BundleIntegrityVerifier {
+    public static boolean isLocalBundleValid(final File localBundleFolder,
+                                             final ZincManifest manifest,
+                                             final String flavorName) {
+        boolean isValid = true;
+        final Map<String, ZincManifest.FileInfo> files = manifest.getFilesWithFlavor(flavorName);
+
+        for (final Map.Entry<String, ZincManifest.FileInfo> entry : files.entrySet()) {
+            final String fileName = entry.getKey();
+            final ZincManifest.FileInfo fileInfo = entry.getValue();
+            final File localFile = new File(localBundleFolder, fileName);
+            final String expectedHash = fileInfo.getHash();
+            isValid = isValid && isLocalFileValid(localFile, expectedHash);
+        }
+
+        return isValid;
+    }
+
+    private static boolean isLocalFileValid(final File localFile,
+                                            final String expectedHash) {
+        boolean isValid = false;
+        final HashUtil hashUtil = new HashUtil();
+
+        try {
+            final ValidatingDigestInputStream digestStream = hashUtil.wrapInputStreamWithDigest(new FileInputStream(localFile));
+            digestStream.validate(expectedHash);
+            isValid = true;
+        } catch (FileNotFoundException e) {
+        } catch (ValidatingDigestInputStream.HashFailedException e) {}
+
+        return isValid;
+    }
+}

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifier.java
@@ -4,8 +4,6 @@ import com.mindsnacks.zinc.classes.data.ZincManifest;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/FileHelper.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/FileHelper.java
@@ -107,7 +107,7 @@ public class FileHelper {
     }
 
     /**
-     * Removes all the files from a directory. Not recursively.
+     * Removes all the files from a directory. Recursively.
      * @param folder directory to empty
      * @return true if all the files were correctly removed.
      */
@@ -116,6 +116,9 @@ public class FileHelper {
 
         if (folder.exists()) {
             for (final File file : folder.listFiles()) {
+                if (file.isDirectory()) {
+                    emptyDirectory(file);
+                }
                 result &= removeFile(file);
             }
         }

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/HashUtil.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/HashUtil.java
@@ -2,6 +2,7 @@ package com.mindsnacks.zinc.classes.fileutils;
 
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
 
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -23,6 +24,10 @@ public class HashUtil {
 
     public ValidatingDigestOutputStream wrapOutputStreamWithDigest(OutputStream outputStream) {
         return new ValidatingDigestOutputStream(outputStream, newDigest());
+    }
+
+    public ValidatingDigestInputStream wrapInputStreamWithDigest(InputStream outputStream) {
+        return new ValidatingDigestInputStream(outputStream, newDigest());
     }
 
     public class HashUtilRuntimeException extends ZincRuntimeException {

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/MessageDigestUtils.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/MessageDigestUtils.java
@@ -1,0 +1,16 @@
+package com.mindsnacks.zinc.classes.fileutils;
+
+import java.security.MessageDigest;
+
+/**
+ * Created by Miguel Carranza on 6/29/15.
+ */
+public class MessageDigestUtils {
+    public static String toHexString(final MessageDigest digest) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : digest.digest()) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestInputStream.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestInputStream.java
@@ -1,0 +1,53 @@
+package com.mindsnacks.zinc.classes.fileutils;
+
+
+import com.mindsnacks.zinc.exceptions.ZincException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.DigestInputStream;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+
+/**
+ * @author Miguel Carranza
+ */
+public class ValidatingDigestInputStream extends DigestInputStream {
+
+    public ValidatingDigestInputStream(InputStream stream, MessageDigest digest) {
+        super(stream, digest);
+    }
+
+    public void validate(String expectedHash) throws HashFailedException {
+        final byte[] buffer = new byte[1024];
+
+        try {
+            for (int read = 0; (read = in.read(buffer)) != -1;) {
+                digest.update(buffer, 0, read);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        String hash = toHexString(getMessageDigest());
+        if (!hash.equals(expectedHash)) {
+            throw new HashFailedException("File hash (" + hash + ") does not match expected hash (" + expectedHash + ").");
+        }
+    }
+
+    public String toHexString(MessageDigest digest) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : digest.digest()) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+
+    public static final class HashFailedException extends ZincException {
+
+        public HashFailedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestInputStream.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestInputStream.java
@@ -5,9 +5,7 @@ import com.mindsnacks.zinc.exceptions.ZincException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.security.DigestInputStream;
-import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 
 /**
@@ -20,28 +18,10 @@ public class ValidatingDigestInputStream extends DigestInputStream {
     }
 
     public void validate(String expectedHash) throws HashFailedException {
-        final byte[] buffer = new byte[1024];
-
-        try {
-            for (int read = 0; (read = in.read(buffer)) != -1;) {
-                digest.update(buffer, 0, read);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        String hash = toHexString(getMessageDigest());
+        String hash = MessageDigestUtils.toHexString(getMessageDigest());
         if (!hash.equals(expectedHash)) {
             throw new HashFailedException("File hash (" + hash + ") does not match expected hash (" + expectedHash + ").");
         }
-    }
-
-    public String toHexString(MessageDigest digest) {
-        StringBuilder builder = new StringBuilder();
-        for (byte b : digest.digest()) {
-            builder.append(String.format("%02x", b));
-        }
-        return builder.toString();
     }
 
     public static final class HashFailedException extends ZincException {

--- a/src/main/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestOutputStream.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestOutputStream.java
@@ -17,18 +17,10 @@ public class ValidatingDigestOutputStream extends DigestOutputStream {
     }
 
     public void validate(String expectedHash) throws HashFailedException {
-        String hash = toHexString(getMessageDigest());
+        String hash = MessageDigestUtils.toHexString(getMessageDigest());
         if (!hash.equals(expectedHash)) {
             throw new HashFailedException("File hash (" + hash + ") does not match expected hash (" + expectedHash + ").");
         }
-    }
-
-    public String toHexString(MessageDigest digest) {
-        StringBuilder builder = new StringBuilder();
-        for (byte b : digest.digest()) {
-            builder.append(String.format("%02x", b));
-        }
-        return builder.toString();
     }
 
     public static final class HashFailedException extends ZincException {

--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
@@ -2,6 +2,7 @@ package com.mindsnacks.zinc.classes.jobs;
 
 import com.mindsnacks.zinc.classes.ZincJobFactory;
 import com.mindsnacks.zinc.classes.data.*;
+import com.mindsnacks.zinc.classes.fileutils.BundleIntegrityVerifier;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
 
 import java.io.File;
@@ -36,12 +37,11 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
         mVersion = getBundleVersion(mBundleID);
 
         final File localBundleFolder = getLocalBundleFolder();
+        final ZincManifest manifest = getManifest();
+        final String flavorName = mRequest.getFlavorName();
 
-        if (shouldDownloadBundle(localBundleFolder)) {
+        if (shouldDownloadBundle(localBundleFolder, manifest, flavorName)) {
             createFolder(localBundleFolder);
-
-            final ZincManifest manifest = getManifest();
-            final String flavorName = mRequest.getFlavorName();
 
             if (manifest.containsFiles(flavorName)) {
                 if (manifest.archiveExists(flavorName)) {
@@ -61,10 +61,12 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
         }
     }
 
-    private boolean shouldDownloadBundle(final File localBundleFolder) {
-//        return true;
-        // TODO: extract this logic as a first step to implement bundle verification
-        return (!localBundleFolder.exists() || localBundleFolder.listFiles().length == 0);
+    private boolean shouldDownloadBundle(final File localBundleFolder,
+                                         final ZincManifest manifest,
+                                         final String flavorName) {
+        return (!localBundleFolder.exists() ||
+                localBundleFolder.listFiles().length == 0 ||
+                !BundleIntegrityVerifier.isLocalBundleValid(localBundleFolder, manifest, flavorName));
     }
 
     private void createFolder(final File folder) {

--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
@@ -16,15 +16,18 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
     private final ZincCloneBundleRequest mRequest;
     private final ZincJobFactory mJobFactory;
     private final Future<ZincCatalog> mCatalogFuture;
+    private final ZincManifestsCache mManifests;
     private BundleID mBundleID;
     private int mVersion;
 
     public ZincCloneBundleJob(final ZincCloneBundleRequest request,
                               final ZincJobFactory jobFactory,
-                              final Future<ZincCatalog> catalogFuture) {
+                              final Future<ZincCatalog> catalogFuture,
+                              final ZincManifestsCache manifests) {
         mRequest = request;
         mJobFactory = jobFactory;
         mCatalogFuture = catalogFuture;
+        mManifests = manifests;
     }
 
     @Override
@@ -97,10 +100,9 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
     }
 
     private ZincManifest getManifest() throws Exception {
-        return mJobFactory.downloadManifest(
-                mRequest.getSourceURL(),
-                mBundleID.getBundleName(),
-                mVersion).call();
+        return mManifests.getManifest(mRequest.getSourceURL(),
+                                      mBundleID.getBundleName(),
+                                      mVersion).get();
     }
 
     private File getLocalBundleFolder() {

--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincCloneBundleJob.java
@@ -59,6 +59,7 @@ public class ZincCloneBundleJob extends ZincJob<ZincBundle> {
     }
 
     private boolean shouldDownloadBundle(final File localBundleFolder) {
+//        return true;
         // TODO: extract this logic as a first step to implement bundle verification
         return (!localBundleFolder.exists() || localBundleFolder.listFiles().length == 0);
     }

--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincDownloader.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincDownloader.java
@@ -57,8 +57,8 @@ public class ZincDownloader implements ZincJobFactory {
     }
 
     @Override
-    public Callable<ZincBundle> cloneBundle(final ZincCloneBundleRequest request, final Future<ZincCatalog> catalogFuture) {
-        return new ZincCloneBundleJob(request, this, catalogFuture);
+    public Callable<ZincBundle> cloneBundle(final ZincCloneBundleRequest request, final Future<ZincCatalog> catalogFuture, final ZincManifestsCache manifests) {
+        return new ZincCloneBundleJob(request, this, catalogFuture, manifests);
     }
 
     @Override

--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincUnarchiveBundleJob.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincUnarchiveBundleJob.java
@@ -91,6 +91,7 @@ public class ZincUnarchiveBundleJob extends ZincJob<ZincBundle> {
 
     private void moveToBundlesFolder(final File temporaryFolder, final File bundleFolder) {
         logMessage("moving bundle");
+        mFileHelper.removeDirectory(bundleFolder);
 
         if ((!bundleFolder.exists() && !bundleFolder.mkdirs()) || !mFileHelper.moveFile(temporaryFolder, bundleFolder)) {
             throw new ZincRuntimeException(String.format("Error moving bundle from '%s' to '%s'", temporaryFolder, bundleFolder));

--- a/src/test/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifierTest.java
+++ b/src/test/java/com/mindsnacks/zinc/classes/fileutils/BundleIntegrityVerifierTest.java
@@ -1,0 +1,104 @@
+package com.mindsnacks.zinc.classes.fileutils;
+
+import com.mindsnacks.zinc.classes.data.ZincManifest;
+import com.mindsnacks.zinc.utils.TestFactory;
+import com.mindsnacks.zinc.utils.TestUtils;
+import com.mindsnacks.zinc.utils.ZincBaseTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by Miguel Carranza on 6/30/15.
+ */
+public class BundleIntegrityVerifierTest extends ZincBaseTest {
+    @Rule
+    public final TemporaryFolder rootFolder = new TemporaryFolder();
+    private final String mFlavorName = "peanut_butter";
+    private final String mFilename1 = "file1.txt",
+                         mFilename2 = "file2.txt",
+                         mFilename3 = "file3.txt";
+    private File mFile1, mFile2, mFile3;
+    private String mContent1, mContent2, mContent3;
+    private String mExpectedHash1, mExpectedHash2, mExpectedHash3;
+
+    @Mock
+    private ZincManifest mZincManifest;
+
+    @Before
+    public void setUp() throws Exception {
+        mContent1 = TestFactory.randomString();
+        mContent2 = TestFactory.randomString();
+        mContent3 = TestFactory.randomString();
+
+        mFile1 = TestUtils.createFile(rootFolder, mFilename1, mContent1);
+        mFile2 = TestUtils.createFile(rootFolder, mFilename2, mContent2);
+        mFile3 = TestUtils.createFile(rootFolder, mFilename3, mContent3);
+
+        mExpectedHash1 = TestUtils.sha1HashString(mContent1);
+        mExpectedHash2 = TestUtils.sha1HashString(mContent2);
+        mExpectedHash3 = TestUtils.sha1HashString(mContent3);
+    }
+
+    @Test
+    public void containsAllFilesAndHaveExpectedHash() {
+        setUpManifest(createFilesWithFlavorsMap());
+
+        assertTrue(BundleIntegrityVerifier.isLocalBundleValid(rootFolder.getRoot(),
+                                                              mZincManifest,
+                                                              mFlavorName));
+    }
+
+    @Test
+    public void containsAllFilesButHashIsIncorrect() {
+        mExpectedHash2 = "super wrong hash";
+        setUpManifest(createFilesWithFlavorsMap());
+
+        assertFalse(BundleIntegrityVerifier.isLocalBundleValid(rootFolder.getRoot(),
+                mZincManifest,
+                mFlavorName));
+    }
+
+    @Test
+    public void doesNotContainAllFiles() {
+        Map<String, ZincManifest.FileInfo> filesWithFlavorMap = createFilesWithFlavorsMap();
+        filesWithFlavorMap.put("file_tocapelotas.txt", stubFileInfo("hash does not matter"));
+        setUpManifest(filesWithFlavorMap);
+
+        assertFalse(BundleIntegrityVerifier.isLocalBundleValid(rootFolder.getRoot(),
+                mZincManifest,
+                mFlavorName));
+    }
+
+    private ZincManifest.FileInfo stubFileInfo(String expectedHash) {
+        ZincManifest.FileInfo res = mock(ZincManifest.FileInfo.class);
+        when(res.getHash()).thenReturn(expectedHash);
+
+        return res;
+    }
+
+    private void setUpManifest(Map<String, ZincManifest.FileInfo> files) {
+        when(mZincManifest.getFilesWithFlavor(mFlavorName)).thenReturn(files);
+    }
+
+    private Map<String, ZincManifest.FileInfo> createFilesWithFlavorsMap() {
+        Map<String, ZincManifest.FileInfo> res = new HashMap<String, ZincManifest.FileInfo>();
+        res.put(mFilename1, stubFileInfo(mExpectedHash1));
+        res.put(mFilename2, stubFileInfo(mExpectedHash2));
+        res.put(mFilename3, stubFileInfo(mExpectedHash3));
+
+        return res;
+    }
+}

--- a/src/test/java/com/mindsnacks/zinc/classes/fileutils/FileHelperTest.java
+++ b/src/test/java/com/mindsnacks/zinc/classes/fileutils/FileHelperTest.java
@@ -116,8 +116,13 @@ public class FileHelperTest extends ZincBaseTest {
 
     @Test
     public void removeDirectory() throws Exception {
+        final File subFolder = rootFolder.newFolder("subFolder");
+        final File file3 = new File(subFolder, "file3.txt");
+        TestUtils.writeToFile(file3, "file3");
+
         assertTrue(file1.exists());
         assertTrue(file2.exists());
+        assertTrue(file3.exists());
 
         // run
         assertTrue(mHelper.removeDirectory(mBundle));
@@ -125,6 +130,7 @@ public class FileHelperTest extends ZincBaseTest {
         assertFalse(mBundle.exists());
         assertFalse(file1.exists());
         assertFalse(file2.exists());
+        assertFalse(file3.exists());
     }
 
     @Test

--- a/src/test/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestInputStreamTest.java
+++ b/src/test/java/com/mindsnacks/zinc/classes/fileutils/ValidatingDigestInputStreamTest.java
@@ -1,0 +1,52 @@
+package com.mindsnacks.zinc.classes.fileutils;
+
+import com.mindsnacks.zinc.utils.TestUtils;
+import com.mindsnacks.zinc.utils.ZincBaseTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.io.FileInputStream;
+import java.io.File;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static com.mindsnacks.zinc.utils.TestFactory.randomString;
+
+public class ValidatingDigestInputStreamTest extends ZincBaseTest {
+
+    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
+    private HashUtil mHashUtil;
+    private String mContents;
+    private String mHash;
+    private ValidatingDigestInputStream mStream;
+    private File mFile;
+    private static final int BUFFER_SIZE = 8192;
+
+    @Before
+    public void setup() throws IOException {
+        mHashUtil = new HashUtil();
+        mContents = randomString();
+        mHash = TestUtils.sha1HashString(mContents);
+        mFile = TestUtils.createFile(rootFolder, "fail.txt", mContents);
+        mStream = setupDigestStream();
+    }
+
+    @Test
+    public void testValidStream() throws ValidatingDigestInputStream.HashFailedException {
+        mStream.validate(mHash);
+    }
+
+    @Test(expected = ValidatingDigestInputStream.HashFailedException.class)
+    public void testInvalidStream() throws ValidatingDigestInputStream.HashFailedException {
+        mStream.validate(mHash + "NOT_THE_HASH");
+    }
+
+    private ValidatingDigestInputStream setupDigestStream() throws IOException {
+        ValidatingDigestInputStream stream = new ValidatingDigestInputStream(new FileInputStream(mFile), mHashUtil.newDigest());
+        final byte[] bytes = new byte[BUFFER_SIZE];
+        for (int read = 0; (read = stream.read(bytes, 0, BUFFER_SIZE)) !=-1;) {}
+        return stream;
+    }
+}

--- a/src/test/java/com/mindsnacks/zinc/data/PathHelperTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/PathHelperTest.java
@@ -67,7 +67,7 @@ public class PathHelperTest extends ZincBaseTest {
     }
 
     @Test
-    public void localCatalogFolder() throws Exception {
+    public void localCatalogFilePath() throws Exception {
         final String catalogID = "com.mindsnacks.games";
 
         final String result = PathHelper.getLocalCatalogFilePath(catalogID);
@@ -77,7 +77,24 @@ public class PathHelperTest extends ZincBaseTest {
     }
 
     @Test
+    public void localManifestFilePath() {
+        final String catalogID = "com.mindsnacks.games";
+        final String manifestID = "watto-1";
+
+        final String result = PathHelper.getLocalManifestFilePath(catalogID, manifestID);
+
+        assertTrue(result.contains(catalogID));
+        assertTrue(result.contains(manifestID));
+        assertTrue(result.endsWith(".json"));
+    }
+
+    @Test
     public void catalogsFolder() throws Exception {
         assertTrue(PathHelper.getCatalogsFolder().endsWith("/"));
+    }
+
+    @Test
+    public void manifestsFolder() throws Exception {
+        assertTrue(PathHelper.getManifestsFolder().endsWith("/"));
     }
 }

--- a/src/test/java/com/mindsnacks/zinc/data/ZincCatalogsTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/ZincCatalogsTest.java
@@ -52,6 +52,7 @@ public class ZincCatalogsTest extends ZincBaseTest {
     @Mock private ListeningExecutorService mExecutorService;
     @Mock private ZincCatalog mResultCatalog;
     @Mock private Timer mTimer;
+    @Mock private File mCatalogFile;
 
     private TimerTask mScheduledTask;
     private boolean runTaskImmediately = false;
@@ -73,14 +74,14 @@ public class ZincCatalogsTest extends ZincBaseTest {
     }
 
     private void initialize() {
-        catalogs = new ZincCatalogs(
-                rootFolder.getRoot(),
-                mFileHelper,
-                mTrackedSourceURLs,
-                mJobFactory,
-                mExecutorService,
-                MoreExecutors.sameThreadExecutor(),
-                mTimer);
+        catalogs = spy(new ZincCatalogs(rootFolder.getRoot(),
+                                        mFileHelper,
+                                        mTrackedSourceURLs,
+                                        mJobFactory,
+                                        mExecutorService,
+                                        MoreExecutors.sameThreadExecutor(),
+                                        mTimer));
+        setCatalogFileLength((long)1);
     }
 
     private void scheduleUpdate() {
@@ -324,6 +325,11 @@ public class ZincCatalogsTest extends ZincBaseTest {
                 return null;
             }
         }).when(mTimer).schedule(any(TimerTask.class), anyLong(), anyLong());
+    }
+
+    private void setCatalogFileLength(final long length) {
+        doReturn((long)1).when(mCatalogFile).length();
+        doReturn(mCatalogFile).when(catalogs).getCatalogFile(mSourceURL);
     }
 
     private void runScheduledTask() {

--- a/src/test/java/com/mindsnacks/zinc/data/ZincCatalogsTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/ZincCatalogsTest.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.gson.JsonSyntaxException;
 import com.mindsnacks.zinc.classes.ZincJobFactory;
 import com.mindsnacks.zinc.classes.data.SourceURL;
 import com.mindsnacks.zinc.classes.data.ZincCatalog;
@@ -12,6 +13,7 @@ import com.mindsnacks.zinc.classes.fileutils.FileHelper;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
 import com.mindsnacks.zinc.utils.TestFactory;
 import com.mindsnacks.zinc.utils.ZincBaseTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,9 +39,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
-
-import com.google.gson.JsonSyntaxException;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * User: NachoSoto
@@ -157,7 +165,7 @@ public class ZincCatalogsTest extends ZincBaseTest {
     }
 
     @Test
-    public void catalogIsDownloadedIfFileContainsJSON() throws Exception {
+    public void catalogIsDownloadedIfFileContainsInvalidJSON() throws Exception {
         setLocalCatalogFileContainsInvalidJSON();
 
         setMockFutureAsResult();

--- a/src/test/java/com/mindsnacks/zinc/data/ZincManifestsTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/ZincManifestsTest.java
@@ -1,0 +1,226 @@
+package com.mindsnacks.zinc.data;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.gson.JsonSyntaxException;
+import com.mindsnacks.zinc.classes.ZincJobFactory;
+import com.mindsnacks.zinc.classes.data.SourceURL;
+import com.mindsnacks.zinc.classes.data.ZincManifest;
+import com.mindsnacks.zinc.classes.data.ZincManifests;
+import com.mindsnacks.zinc.classes.fileutils.FileHelper;
+import com.mindsnacks.zinc.utils.TestFactory;
+import com.mindsnacks.zinc.utils.ZincBaseTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.verification.VerificationMode;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.MalformedURLException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.atLeastOnce;
+
+/**
+ * Created by Miguel Carranza on 6/30/15.
+ */
+public class ZincManifestsTest extends ZincBaseTest {
+    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
+
+    @Mock private ZincJobFactory mJobFactory;
+    @Mock private FileHelper mFileHelper;
+    @Mock private ListeningExecutorService mExecutorService;
+    @Mock private ZincManifest mResultManifest;
+    @Mock private File mManifestFile;
+
+    private static final String mCatalogID = "com.mindsnacks.games";
+    private static final String mBundleName = "bundle";
+    private static final int mVersion = 25;
+
+    private final SourceURL mSourceURL;
+    private ZincManifests manifests;
+
+    public ZincManifestsTest() throws MalformedURLException {
+        mSourceURL = new SourceURL(TestFactory.createURL("http://www.mindsnacks.com"), mCatalogID);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        initialize();
+    }
+
+    private void initialize() {
+        manifests = spy(new ZincManifests(rootFolder.getRoot(),
+                                          mFileHelper,
+                                          mJobFactory,
+                                          mExecutorService,
+                                          MoreExecutors.sameThreadExecutor()));
+        setLocalManifestFileLength((long) 1);
+    }
+
+    private Future<ZincManifest> run() {
+        return manifests.getManifest(mSourceURL, mBundleName, mVersion);
+    }
+
+    @Test
+    public void clearCachedManifests() throws Exception {
+        manifests.clearCachedManifests();
+
+        verify(mFileHelper).emptyDirectory(any(File.class));
+    }
+
+    @Test
+    public void returnsLocalManifestIfExists() throws Exception {
+        setLocalManifestFileContent();
+
+        final Future<ZincManifest> manifest = run();
+
+        // verify
+        assertNotNull(manifest);
+        assertEquals(mResultManifest, manifest.get());
+    }
+
+    @Test
+    public void JSONIsReadFromDisk() throws Exception {
+        setLocalManifestFileContent();
+
+        run();
+
+        verify(mFileHelper).readJSON(any(File.class), eq(ZincManifest.class));
+    }
+
+    @Test
+    public void manifestIsDownloadedIfFileNotPresent() throws Exception {
+        setLocalManifestFileDoesNotExist();
+        setMockFutureAsResult();
+
+        run();
+
+        verifyManifestIsDownloaded();
+    }
+
+    @Test
+    public void manifestIsDownloadedIfFileSizeIsZero() throws Exception {
+        setLocalManifestFileContent();
+        setLocalManifestFileLength(0);
+
+        setMockFutureAsResult();
+
+        run();
+
+        verifyManifestIsDownloaded();
+    }
+
+    @Test
+    public void manifestIsDownloadedIfFileContainsInvalidJSON() throws Exception {
+        setLocalManifestFileContainsInvalidJSON();
+
+        setMockFutureAsResult();
+
+        run();
+
+        verifyManifestIsDownloaded();
+    }
+
+    @Test
+    public void manifestDownloadIsSubmitted() throws Exception {
+        final Callable downloadTask = mock(Callable.class);
+
+        setLocalManifestFileDoesNotExist();
+        setMockFutureAsResult();
+        doReturn(downloadTask).when(mJobFactory).downloadManifest(mSourceURL, mBundleName, mVersion);
+
+        run();
+
+        verify(mExecutorService).submit(downloadTask);
+    }
+
+    @Test
+    public void returnedFutureComesFromExecutorService() throws Exception {
+        setLocalManifestFileDoesNotExist();
+        final ListenableFuture future = setMockFutureAsResult();
+
+        assertEquals(future, run());
+    }
+
+    @Test
+    public void manifestIsPersisted() throws Exception {
+        final SettableFuture<ZincManifest> future = SettableFuture.create();
+        future.set(mResultManifest);
+
+        setLocalManifestFileDoesNotExist();
+        setFuture(future);
+
+        run();
+
+        verify(mFileHelper).writeObject(any(File.class), eq(mResultManifest), eq(ZincManifest.class));
+    }
+
+    @Test
+    public void futuresAreCached() throws Exception {
+        setLocalManifestFileContent();
+
+        final Future<ZincManifest> future1 = run(),
+                                  future2 = run();
+
+        assertEquals(future1, future2);
+
+        verify(mFileHelper, times(1)).readJSON(any(File.class), eq(ZincManifest.class));
+    }
+
+    private void setLocalManifestFileContent() throws FileNotFoundException {
+        doReturn(mResultManifest).when(mFileHelper).readJSON(any(File.class), eq(ZincManifest.class));
+    }
+
+    private void setLocalManifestFileDoesNotExist() throws FileNotFoundException {
+        doThrow(FileNotFoundException.class).when(mFileHelper).readJSON(any(File.class), any(Class.class));
+    }
+
+    private void setLocalManifestFileContainsInvalidJSON() throws FileNotFoundException {
+        doThrow(JsonSyntaxException.class).when(mFileHelper).readJSON(any(File.class), any(Class.class));
+    }
+
+    private void verifyManifestIsDownloaded() {
+        verifManifestIsDownloaded(atLeastOnce());
+    }
+
+    private void verifManifestIsDownloaded(final VerificationMode times) {
+        verify(mJobFactory, times).downloadManifest(mSourceURL, mBundleName, mVersion);
+    }
+
+    private ListenableFuture setMockFutureAsResult() {
+        final ListenableFuture future = mock(ListenableFuture.class);
+
+        setFuture(future);
+
+        return future;
+    }
+
+    private void setFuture(final ListenableFuture future) {
+        doReturn(future).when(mExecutorService).submit(Matchers.<Callable>any());
+    }
+
+    private void setLocalManifestFileLength(final long length) {
+        doReturn((long)length).when(mManifestFile).length();
+        doReturn(mManifestFile).when(manifests).getManifestFile(eq(mCatalogID), anyString());
+    }
+}

--- a/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
+++ b/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
@@ -28,226 +28,226 @@ import static org.mockito.Mockito.*;
  * User: NachoSoto
  * Date: 9/19/13
  */
-public class ZincCloneBundleJobTest extends ZincBaseTest {
-    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
-
-    @Mock private SourceURL mSourceURL;
-    @Mock private BundleID mBundleID;
-    @Mock private Callable<ZincBundle> mDownloadBundleJob;
-    @Mock private Callable<ZincBundle> mResultBundleJob;
-    @Mock private Callable<ZincManifest> mZincManifestJob;
-    @Mock private Callable<File> mDownloadFileJob;
-    @Mock private ZincBundle mResultBundle;
-    @Mock private ZincBundle mDownloadedBundle;
-    @Mock private ZincJobFactory mJobFactory;
-    @Mock private Future<ZincCatalog> mZincCatalogFuture;
-    @Mock private ZincCatalog mZincCatalog;
-    @Mock private ZincManifest mZincManifest;
-    @Mock private ZincManifest.FileInfo mFileWithFlavor;
-    private URL mObjectURL;
-
-    private final String mDistribution = "master";
-    private final String mFlavorName = "retina";
-    private final String mSingleFilename = "some-file";
-
-    private int mVersion = 10;
-    private final String mBundleName = "bundle";
-
-    private File mRepoFolder;
-    private File mDownloadedFile;
-
-    private ZincCloneBundleRequest mRequest;
-    private ZincCloneBundleJob job;
-
-    @Before
-    public void setUp() throws Exception {
-        mRepoFolder = rootFolder.getRoot();
-        mDownloadedFile = new File(rootFolder.getRoot(), "downloaded file");
-        mObjectURL = new URL("https://www.nsa.gov");
-
-        mRequest = new ZincCloneBundleRequest(mSourceURL, mBundleID, mDistribution, mFlavorName, mRepoFolder);
-        job = new ZincCloneBundleJob(mRequest, mJobFactory, mZincCatalogFuture);
-
-        when(mJobFactory.downloadBundle(eq(mRequest), eq(mZincCatalogFuture))).thenReturn(mDownloadBundleJob);
-        when(mJobFactory.downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion))).thenReturn(mZincManifestJob);
-        when(mJobFactory.unarchiveBundle(any(ZincBundle.class), eq(mRequest), eq(mZincManifest))).thenReturn(mResultBundleJob);
-        when(mJobFactory.downloadFile(eq(mObjectURL), any(File.class), eq(mRepoFolder), eq(mSingleFilename), anyBoolean(), anyString())).thenReturn(mDownloadFileJob);
-
-        TestFactory.setCallableResult(mDownloadBundleJob, mDownloadedBundle);
-        TestFactory.setCallableResult(mDownloadFileJob, mDownloadedFile);
-        TestFactory.setCallableResult(mResultBundleJob, mResultBundle);
-        TestFactory.setCallableResult(mZincManifestJob, mZincManifest);
-        TestFactory.setFutureResult(mZincCatalogFuture, mZincCatalog);
-
-        when(mBundleID.getBundleName()).thenReturn(mBundleName);
-        when(mZincCatalog.getVersionForBundleName(mBundleName, mDistribution)).thenReturn(mVersion);
-        when(mZincManifest.getFileWithFlavor(mFlavorName)).thenReturn(mFileWithFlavor);
-        when(mZincManifest.getFilenameWithFlavor(mFlavorName)).thenReturn(mSingleFilename);
-        when(mSourceURL.getObjectURL(mFileWithFlavor)).thenReturn(mObjectURL);
-
-        setManifestContainsFiles(true);
-        setManifestArchiveExists(true);
-    }
-
-    @Test
-    public void bundleIsDownloaded() throws Exception {
-        run();
-
-        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
-    }
-
-    @Test
-    public void manifestIsDownloaded() throws Exception {
-        run();
-
-        verify(mJobFactory).downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion));
-    }
-
-    @Test
-    public void bundleIsUnarchived() throws Exception {
-        run();
-
-        verify(mJobFactory).unarchiveBundle(eq(mDownloadedBundle), eq(mRequest), eq(mZincManifest));
-    }
-
-    @Test
-    public void resultIsCorrect() throws Exception {
-        assertEquals(mResultBundle, run());
-    }
-
-    @Test
-    public void bundleIDownloadedIfItAlreadyExistsButItsEmpty() throws Exception {
-        createExpectedResultDirectory();
-
-        run();
-
-        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
-    }
-
-    @Test
-    public void bundleIsNotDownloadedIfItAlreadyExists() throws Exception {
-        createExpectedResultDirectoryWithFiles();
-
-        run();
-
-        verifyBundleIsNotUnarchived();
-        verifyArchiveIsNotDownloaded();
-    }
-
-    @Test
-    public void bundleIsReturnedIfItAlreadyExists() throws Exception {
-        verifyResult(createExpectedResultDirectoryWithFiles(), run());
-    }
-
-    @Test
-    public void bundleIsCorrectIfManifestContainsNoFiles() throws Exception {
-        setManifestContainsFiles(false);
-
-        verifyResult(
-                new ZincBundle(expectedResultDirectory(),
-                        mBundleID,
-                        mVersion),
-                run());
-    }
-
-    @Test
-    public void bundleFolderIsEmptyIfManifestContainsNoFiles() throws Exception {
-        setManifestContainsFiles(false);
-
-        final ZincBundle result = run();
-
-        assertTrue(result.exists());
-        assertEquals(0, result.listFiles().length);
-    }
-
-    @Test
-    public void nothingIsDownloadedIfManifestContainsNoFiles() throws Exception {
-        setManifestContainsFiles(false);
-
-        run();
-
-        verifyArchiveIsNotDownloaded();
-    }
-
-    @Test
-    public void archiveIsNotDownloadedIfItDoesntExist() throws Exception {
-        setManifestArchiveExists(false);
-
-        run();
-
-        verifyArchiveIsNotDownloaded();
-    }
-
-    @Test
-    public void fileIsDownloadedIfThereIsNoArchive() throws Exception {
-        final File expectedResultDirectory = expectedResultDirectory();
-
-        setManifestArchiveExists(false);
-
-        run();
-
-        verify(mJobFactory).downloadFile(eq(mObjectURL), eq(expectedResultDirectory), eq(mRepoFolder), eq(mSingleFilename), eq(false), anyString());
-    }
-
-    @Test
-    public void bundleIsCorrectIfOnlyOneFileIsDownloaded() throws Exception {
-        setManifestArchiveExists(false);
-
-        verifyResult(mDownloadedFile.getParentFile(), run());
-    }
-
-    private File createExpectedResultDirectory() throws IOException {
-        final File file = expectedResultDirectory();
-
-        assert file.getParentFile().exists() || file.mkdirs();
-        assert file.exists() || file.createNewFile();
-
-        assert file.exists();
-
-        return file;
-    }
-
-    private File createExpectedResultDirectoryWithFiles() throws IOException {
-        final File folder = createExpectedResultDirectory();
-
-        TestUtils.createRandomFileInFolder(folder);
-
-        return folder;
-    }
-
-    private File expectedResultDirectory() {
-        return new File(
-                mRepoFolder,
-                PathHelper.getLocalBundleFolder(mBundleID, mVersion, mFlavorName));
-    }
-
-    private void setManifestContainsFiles(final boolean containsFiles) {
-        when(mZincManifest.containsFiles(mFlavorName)).thenReturn(containsFiles);
-    }
-
-    private void setManifestArchiveExists(final boolean exists) {
-        when(mZincManifest.archiveExists(mFlavorName)).thenReturn(exists);
-    }
-
-    private void verifyBundleIsNotUnarchived() {
-        verify(mJobFactory, times(0)).unarchiveBundle(any(ZincBundle.class), any(ZincCloneBundleRequest.class), any(ZincManifest.class));
-    }
-
-    private void verifyArchiveIsNotDownloaded() {
-        verify(mJobFactory, times(0)).downloadBundle(any(ZincCloneBundleRequest.class), anyCatalogFuture());
-    }
-
-    private void verifyResult(final File directory, final ZincBundle result) {
-        assertEquals(directory.getAbsolutePath(), result.getAbsolutePath());
-        assertEquals(mBundleID, result.getBundleID());
-        assertEquals(mVersion, result.getVersion());
-    }
-
-    private static Future<ZincCatalog> anyCatalogFuture() {
-        return Matchers.any();
-    }
-
-    private ZincBundle run() throws Exception {
-        return job.call();
-    }
-}
+//public class ZincCloneBundleJobTest extends ZincBaseTest {
+//    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
+//
+//    @Mock private SourceURL mSourceURL;
+//    @Mock private BundleID mBundleID;
+//    @Mock private Callable<ZincBundle> mDownloadBundleJob;
+//    @Mock private Callable<ZincBundle> mResultBundleJob;
+//    @Mock private Callable<ZincManifest> mZincManifestJob;
+//    @Mock private Callable<File> mDownloadFileJob;
+//    @Mock private ZincBundle mResultBundle;
+//    @Mock private ZincBundle mDownloadedBundle;
+//    @Mock private ZincJobFactory mJobFactory;
+//    @Mock private Future<ZincCatalog> mZincCatalogFuture;
+//    @Mock private ZincCatalog mZincCatalog;
+//    @Mock private ZincManifest mZincManifest;
+//    @Mock private ZincManifest.FileInfo mFileWithFlavor;
+//    private URL mObjectURL;
+//
+//    private final String mDistribution = "master";
+//    private final String mFlavorName = "retina";
+//    private final String mSingleFilename = "some-file";
+//
+//    private int mVersion = 10;
+//    private final String mBundleName = "bundle";
+//
+//    private File mRepoFolder;
+//    private File mDownloadedFile;
+//
+//    private ZincCloneBundleRequest mRequest;
+//    private ZincCloneBundleJob job;
+//
+//    @Before
+//    public void setUp() throws Exception {
+//        mRepoFolder = rootFolder.getRoot();
+//        mDownloadedFile = new File(rootFolder.getRoot(), "downloaded file");
+//        mObjectURL = new URL("https://www.nsa.gov");
+//
+//        mRequest = new ZincCloneBundleRequest(mSourceURL, mBundleID, mDistribution, mFlavorName, mRepoFolder);
+//        job = new ZincCloneBundleJob(mRequest, mJobFactory, mZincCatalogFuture);
+//
+//        when(mJobFactory.downloadBundle(eq(mRequest), eq(mZincCatalogFuture))).thenReturn(mDownloadBundleJob);
+//        when(mJobFactory.downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion))).thenReturn(mZincManifestJob);
+//        when(mJobFactory.unarchiveBundle(any(ZincBundle.class), eq(mRequest), eq(mZincManifest))).thenReturn(mResultBundleJob);
+//        when(mJobFactory.downloadFile(eq(mObjectURL), any(File.class), eq(mRepoFolder), eq(mSingleFilename), anyBoolean(), anyString())).thenReturn(mDownloadFileJob);
+//
+//        TestFactory.setCallableResult(mDownloadBundleJob, mDownloadedBundle);
+//        TestFactory.setCallableResult(mDownloadFileJob, mDownloadedFile);
+//        TestFactory.setCallableResult(mResultBundleJob, mResultBundle);
+//        TestFactory.setCallableResult(mZincManifestJob, mZincManifest);
+//        TestFactory.setFutureResult(mZincCatalogFuture, mZincCatalog);
+//
+//        when(mBundleID.getBundleName()).thenReturn(mBundleName);
+//        when(mZincCatalog.getVersionForBundleName(mBundleName, mDistribution)).thenReturn(mVersion);
+//        when(mZincManifest.getFileWithFlavor(mFlavorName)).thenReturn(mFileWithFlavor);
+//        when(mZincManifest.getFilenameWithFlavor(mFlavorName)).thenReturn(mSingleFilename);
+//        when(mSourceURL.getObjectURL(mFileWithFlavor)).thenReturn(mObjectURL);
+//
+//        setManifestContainsFiles(true);
+//        setManifestArchiveExists(true);
+//    }
+//
+//    @Test
+//    public void bundleIsDownloaded() throws Exception {
+//        run();
+//
+//        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
+//    }
+//
+//    @Test
+//    public void manifestIsDownloaded() throws Exception {
+//        run();
+//
+//        verify(mJobFactory).downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion));
+//    }
+//
+//    @Test
+//    public void bundleIsUnarchived() throws Exception {
+//        run();
+//
+//        verify(mJobFactory).unarchiveBundle(eq(mDownloadedBundle), eq(mRequest), eq(mZincManifest));
+//    }
+//
+//    @Test
+//    public void resultIsCorrect() throws Exception {
+//        assertEquals(mResultBundle, run());
+//    }
+//
+//    @Test
+//    public void bundleIDownloadedIfItAlreadyExistsButItsEmpty() throws Exception {
+//        createExpectedResultDirectory();
+//
+//        run();
+//
+//        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
+//    }
+//
+//    @Test
+//    public void bundleIsNotDownloadedIfItAlreadyExists() throws Exception {
+//        createExpectedResultDirectoryWithFiles();
+//
+//        run();
+//
+//        verifyBundleIsNotUnarchived();
+//        verifyArchiveIsNotDownloaded();
+//    }
+//
+//    @Test
+//    public void bundleIsReturnedIfItAlreadyExists() throws Exception {
+//        verifyResult(createExpectedResultDirectoryWithFiles(), run());
+//    }
+//
+//    @Test
+//    public void bundleIsCorrectIfManifestContainsNoFiles() throws Exception {
+//        setManifestContainsFiles(false);
+//
+//        verifyResult(
+//                new ZincBundle(expectedResultDirectory(),
+//                        mBundleID,
+//                        mVersion),
+//                run());
+//    }
+//
+//    @Test
+//    public void bundleFolderIsEmptyIfManifestContainsNoFiles() throws Exception {
+//        setManifestContainsFiles(false);
+//
+//        final ZincBundle result = run();
+//
+//        assertTrue(result.exists());
+//        assertEquals(0, result.listFiles().length);
+//    }
+//
+//    @Test
+//    public void nothingIsDownloadedIfManifestContainsNoFiles() throws Exception {
+//        setManifestContainsFiles(false);
+//
+//        run();
+//
+//        verifyArchiveIsNotDownloaded();
+//    }
+//
+//    @Test
+//    public void archiveIsNotDownloadedIfItDoesntExist() throws Exception {
+//        setManifestArchiveExists(false);
+//
+//        run();
+//
+//        verifyArchiveIsNotDownloaded();
+//    }
+//
+//    @Test
+//    public void fileIsDownloadedIfThereIsNoArchive() throws Exception {
+//        final File expectedResultDirectory = expectedResultDirectory();
+//
+//        setManifestArchiveExists(false);
+//
+//        run();
+//
+//        verify(mJobFactory).downloadFile(eq(mObjectURL), eq(expectedResultDirectory), eq(mRepoFolder), eq(mSingleFilename), eq(false), anyString());
+//    }
+//
+//    @Test
+//    public void bundleIsCorrectIfOnlyOneFileIsDownloaded() throws Exception {
+//        setManifestArchiveExists(false);
+//
+//        verifyResult(mDownloadedFile.getParentFile(), run());
+//    }
+//
+//    private File createExpectedResultDirectory() throws IOException {
+//        final File file = expectedResultDirectory();
+//
+//        assert file.getParentFile().exists() || file.mkdirs();
+//        assert file.exists() || file.createNewFile();
+//
+//        assert file.exists();
+//
+//        return file;
+//    }
+//
+//    private File createExpectedResultDirectoryWithFiles() throws IOException {
+//        final File folder = createExpectedResultDirectory();
+//
+//        TestUtils.createRandomFileInFolder(folder);
+//
+//        return folder;
+//    }
+//
+//    private File expectedResultDirectory() {
+//        return new File(
+//                mRepoFolder,
+//                PathHelper.getLocalBundleFolder(mBundleID, mVersion, mFlavorName));
+//    }
+//
+//    private void setManifestContainsFiles(final boolean containsFiles) {
+//        when(mZincManifest.containsFiles(mFlavorName)).thenReturn(containsFiles);
+//    }
+//
+//    private void setManifestArchiveExists(final boolean exists) {
+//        when(mZincManifest.archiveExists(mFlavorName)).thenReturn(exists);
+//    }
+//
+//    private void verifyBundleIsNotUnarchived() {
+//        verify(mJobFactory, times(0)).unarchiveBundle(any(ZincBundle.class), any(ZincCloneBundleRequest.class), any(ZincManifest.class));
+//    }
+//
+//    private void verifyArchiveIsNotDownloaded() {
+//        verify(mJobFactory, times(0)).downloadBundle(any(ZincCloneBundleRequest.class), anyCatalogFuture());
+//    }
+//
+//    private void verifyResult(final File directory, final ZincBundle result) {
+//        assertEquals(directory.getAbsolutePath(), result.getAbsolutePath());
+//        assertEquals(mBundleID, result.getBundleID());
+//        assertEquals(mVersion, result.getVersion());
+//    }
+//
+//    private static Future<ZincCatalog> anyCatalogFuture() {
+//        return Matchers.any();
+//    }
+//
+//    private ZincBundle run() throws Exception {
+//        return job.call();
+//    }
+//}

--- a/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
+++ b/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
@@ -28,226 +28,232 @@ import static org.mockito.Mockito.*;
  * User: NachoSoto
  * Date: 9/19/13
  */
-//public class ZincCloneBundleJobTest extends ZincBaseTest {
-//    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
-//
-//    @Mock private SourceURL mSourceURL;
-//    @Mock private BundleID mBundleID;
-//    @Mock private Callable<ZincBundle> mDownloadBundleJob;
-//    @Mock private Callable<ZincBundle> mResultBundleJob;
-//    @Mock private Callable<ZincManifest> mZincManifestJob;
-//    @Mock private Callable<File> mDownloadFileJob;
-//    @Mock private ZincBundle mResultBundle;
-//    @Mock private ZincBundle mDownloadedBundle;
-//    @Mock private ZincJobFactory mJobFactory;
-//    @Mock private Future<ZincCatalog> mZincCatalogFuture;
-//    @Mock private ZincCatalog mZincCatalog;
-//    @Mock private ZincManifest mZincManifest;
-//    @Mock private ZincManifest.FileInfo mFileWithFlavor;
-//    private URL mObjectURL;
-//
-//    private final String mDistribution = "master";
-//    private final String mFlavorName = "retina";
-//    private final String mSingleFilename = "some-file";
-//
-//    private int mVersion = 10;
-//    private final String mBundleName = "bundle";
-//
-//    private File mRepoFolder;
-//    private File mDownloadedFile;
-//
-//    private ZincCloneBundleRequest mRequest;
-//    private ZincCloneBundleJob job;
-//
-//    @Before
-//    public void setUp() throws Exception {
-//        mRepoFolder = rootFolder.getRoot();
-//        mDownloadedFile = new File(rootFolder.getRoot(), "downloaded file");
-//        mObjectURL = new URL("https://www.nsa.gov");
-//
-//        mRequest = new ZincCloneBundleRequest(mSourceURL, mBundleID, mDistribution, mFlavorName, mRepoFolder);
-//        job = new ZincCloneBundleJob(mRequest, mJobFactory, mZincCatalogFuture);
-//
-//        when(mJobFactory.downloadBundle(eq(mRequest), eq(mZincCatalogFuture))).thenReturn(mDownloadBundleJob);
-//        when(mJobFactory.downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion))).thenReturn(mZincManifestJob);
-//        when(mJobFactory.unarchiveBundle(any(ZincBundle.class), eq(mRequest), eq(mZincManifest))).thenReturn(mResultBundleJob);
-//        when(mJobFactory.downloadFile(eq(mObjectURL), any(File.class), eq(mRepoFolder), eq(mSingleFilename), anyBoolean(), anyString())).thenReturn(mDownloadFileJob);
-//
-//        TestFactory.setCallableResult(mDownloadBundleJob, mDownloadedBundle);
-//        TestFactory.setCallableResult(mDownloadFileJob, mDownloadedFile);
-//        TestFactory.setCallableResult(mResultBundleJob, mResultBundle);
-//        TestFactory.setCallableResult(mZincManifestJob, mZincManifest);
-//        TestFactory.setFutureResult(mZincCatalogFuture, mZincCatalog);
-//
-//        when(mBundleID.getBundleName()).thenReturn(mBundleName);
-//        when(mZincCatalog.getVersionForBundleName(mBundleName, mDistribution)).thenReturn(mVersion);
-//        when(mZincManifest.getFileWithFlavor(mFlavorName)).thenReturn(mFileWithFlavor);
-//        when(mZincManifest.getFilenameWithFlavor(mFlavorName)).thenReturn(mSingleFilename);
-//        when(mSourceURL.getObjectURL(mFileWithFlavor)).thenReturn(mObjectURL);
-//
-//        setManifestContainsFiles(true);
-//        setManifestArchiveExists(true);
-//    }
-//
-//    @Test
-//    public void bundleIsDownloaded() throws Exception {
-//        run();
-//
-//        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
-//    }
-//
-//    @Test
-//    public void manifestIsDownloaded() throws Exception {
-//        run();
-//
-//        verify(mJobFactory).downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion));
-//    }
-//
-//    @Test
-//    public void bundleIsUnarchived() throws Exception {
-//        run();
-//
-//        verify(mJobFactory).unarchiveBundle(eq(mDownloadedBundle), eq(mRequest), eq(mZincManifest));
-//    }
-//
-//    @Test
-//    public void resultIsCorrect() throws Exception {
-//        assertEquals(mResultBundle, run());
-//    }
-//
-//    @Test
-//    public void bundleIDownloadedIfItAlreadyExistsButItsEmpty() throws Exception {
-//        createExpectedResultDirectory();
-//
-//        run();
-//
-//        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
-//    }
-//
-//    @Test
-//    public void bundleIsNotDownloadedIfItAlreadyExists() throws Exception {
-//        createExpectedResultDirectoryWithFiles();
-//
-//        run();
-//
-//        verifyBundleIsNotUnarchived();
-//        verifyArchiveIsNotDownloaded();
-//    }
-//
-//    @Test
-//    public void bundleIsReturnedIfItAlreadyExists() throws Exception {
-//        verifyResult(createExpectedResultDirectoryWithFiles(), run());
-//    }
-//
-//    @Test
-//    public void bundleIsCorrectIfManifestContainsNoFiles() throws Exception {
-//        setManifestContainsFiles(false);
-//
-//        verifyResult(
-//                new ZincBundle(expectedResultDirectory(),
-//                        mBundleID,
-//                        mVersion),
-//                run());
-//    }
-//
-//    @Test
-//    public void bundleFolderIsEmptyIfManifestContainsNoFiles() throws Exception {
-//        setManifestContainsFiles(false);
-//
-//        final ZincBundle result = run();
-//
-//        assertTrue(result.exists());
-//        assertEquals(0, result.listFiles().length);
-//    }
-//
-//    @Test
-//    public void nothingIsDownloadedIfManifestContainsNoFiles() throws Exception {
-//        setManifestContainsFiles(false);
-//
-//        run();
-//
-//        verifyArchiveIsNotDownloaded();
-//    }
-//
-//    @Test
-//    public void archiveIsNotDownloadedIfItDoesntExist() throws Exception {
-//        setManifestArchiveExists(false);
-//
-//        run();
-//
-//        verifyArchiveIsNotDownloaded();
-//    }
-//
-//    @Test
-//    public void fileIsDownloadedIfThereIsNoArchive() throws Exception {
-//        final File expectedResultDirectory = expectedResultDirectory();
-//
-//        setManifestArchiveExists(false);
-//
-//        run();
-//
-//        verify(mJobFactory).downloadFile(eq(mObjectURL), eq(expectedResultDirectory), eq(mRepoFolder), eq(mSingleFilename), eq(false), anyString());
-//    }
-//
-//    @Test
-//    public void bundleIsCorrectIfOnlyOneFileIsDownloaded() throws Exception {
-//        setManifestArchiveExists(false);
-//
-//        verifyResult(mDownloadedFile.getParentFile(), run());
-//    }
-//
-//    private File createExpectedResultDirectory() throws IOException {
-//        final File file = expectedResultDirectory();
-//
-//        assert file.getParentFile().exists() || file.mkdirs();
-//        assert file.exists() || file.createNewFile();
-//
-//        assert file.exists();
-//
-//        return file;
-//    }
-//
-//    private File createExpectedResultDirectoryWithFiles() throws IOException {
-//        final File folder = createExpectedResultDirectory();
-//
-//        TestUtils.createRandomFileInFolder(folder);
-//
-//        return folder;
-//    }
-//
-//    private File expectedResultDirectory() {
-//        return new File(
-//                mRepoFolder,
-//                PathHelper.getLocalBundleFolder(mBundleID, mVersion, mFlavorName));
-//    }
-//
-//    private void setManifestContainsFiles(final boolean containsFiles) {
-//        when(mZincManifest.containsFiles(mFlavorName)).thenReturn(containsFiles);
-//    }
-//
-//    private void setManifestArchiveExists(final boolean exists) {
-//        when(mZincManifest.archiveExists(mFlavorName)).thenReturn(exists);
-//    }
-//
-//    private void verifyBundleIsNotUnarchived() {
-//        verify(mJobFactory, times(0)).unarchiveBundle(any(ZincBundle.class), any(ZincCloneBundleRequest.class), any(ZincManifest.class));
-//    }
-//
-//    private void verifyArchiveIsNotDownloaded() {
-//        verify(mJobFactory, times(0)).downloadBundle(any(ZincCloneBundleRequest.class), anyCatalogFuture());
-//    }
-//
-//    private void verifyResult(final File directory, final ZincBundle result) {
-//        assertEquals(directory.getAbsolutePath(), result.getAbsolutePath());
-//        assertEquals(mBundleID, result.getBundleID());
-//        assertEquals(mVersion, result.getVersion());
-//    }
-//
-//    private static Future<ZincCatalog> anyCatalogFuture() {
-//        return Matchers.any();
-//    }
-//
-//    private ZincBundle run() throws Exception {
-//        return job.call();
-//    }
-//}
+public class ZincCloneBundleJobTest extends ZincBaseTest {
+    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
+
+    @Mock private SourceURL mSourceURL;
+    @Mock private BundleID mBundleID;
+    @Mock private Callable<ZincBundle> mDownloadBundleJob;
+    @Mock private Callable<ZincBundle> mResultBundleJob;
+    @Mock private Callable<ZincManifest> mZincManifestJob;
+    @Mock private Callable<File> mDownloadFileJob;
+    @Mock private ZincBundle mResultBundle;
+    @Mock private ZincBundle mDownloadedBundle;
+    @Mock private ZincJobFactory mJobFactory;
+    @Mock private Future<ZincCatalog> mZincCatalogFuture;
+    @Mock private ZincCatalog mZincCatalog;
+    @Mock private Future<ZincManifest> mZincManifestFuture;
+    @Mock private ZincManifest mZincManifest;
+    @Mock private ZincManifest.FileInfo mFileWithFlavor;
+    @Mock private ZincManifests mZincManifests;
+    private URL mObjectURL;
+
+    private final String mDistribution = "master";
+    private final String mFlavorName = "retina";
+    private final String mSingleFilename = "some-file";
+
+    private int mVersion = 10;
+    private final String mBundleName = "bundle";
+
+    private File mRepoFolder;
+    private File mDownloadedFile;
+
+    private ZincCloneBundleRequest mRequest;
+    private ZincCloneBundleJob job;
+
+    @Before
+    public void setUp() throws Exception {
+        mRepoFolder = rootFolder.getRoot();
+        mDownloadedFile = new File(rootFolder.getRoot(), "downloaded file");
+        mObjectURL = new URL("https://www.nsa.gov");
+
+        mRequest = new ZincCloneBundleRequest(mSourceURL, mBundleID, mDistribution, mFlavorName, mRepoFolder);
+        job = new ZincCloneBundleJob(mRequest, mJobFactory, mZincCatalogFuture, mZincManifests);
+
+        when(mJobFactory.downloadBundle(eq(mRequest), eq(mZincCatalogFuture))).thenReturn(mDownloadBundleJob);
+        when(mJobFactory.downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion))).thenReturn(mZincManifestJob);
+        when(mJobFactory.unarchiveBundle(any(ZincBundle.class), eq(mRequest), eq(mZincManifest))).thenReturn(mResultBundleJob);
+        when(mJobFactory.downloadFile(eq(mObjectURL), any(File.class), eq(mRepoFolder), eq(mSingleFilename), anyBoolean(), anyString())).thenReturn(mDownloadFileJob);
+
+        TestFactory.setCallableResult(mDownloadBundleJob, mDownloadedBundle);
+        TestFactory.setCallableResult(mDownloadFileJob, mDownloadedFile);
+        TestFactory.setCallableResult(mResultBundleJob, mResultBundle);
+        TestFactory.setCallableResult(mZincManifestJob, mZincManifest);
+        TestFactory.setFutureResult(mZincCatalogFuture, mZincCatalog);
+        TestFactory.setFutureResult(mZincManifestFuture, mZincManifest);
+
+
+        when(mBundleID.getBundleName()).thenReturn(mBundleName);
+        when(mZincCatalog.getVersionForBundleName(mBundleName, mDistribution)).thenReturn(mVersion);
+        when(mZincManifest.getFileWithFlavor(mFlavorName)).thenReturn(mFileWithFlavor);
+        when(mZincManifest.getFilenameWithFlavor(mFlavorName)).thenReturn(mSingleFilename);
+        when(mSourceURL.getObjectURL(mFileWithFlavor)).thenReturn(mObjectURL);
+
+        when(mZincManifests.getManifest(mSourceURL, mBundleName, mVersion)).thenReturn(mZincManifestFuture);
+
+        setManifestContainsFiles(true);
+        setManifestArchiveExists(true);
+    }
+
+    @Test
+    public void bundleIsDownloaded() throws Exception {
+        run();
+
+        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
+    }
+
+    @Test
+    public void manifestIsDownloaded() throws Exception {
+        run();
+
+        verify(mZincManifestFuture).get();
+    }
+
+    @Test
+    public void bundleIsUnarchived() throws Exception {
+        run();
+
+        verify(mJobFactory).unarchiveBundle(eq(mDownloadedBundle), eq(mRequest), eq(mZincManifest));
+    }
+
+    @Test
+    public void resultIsCorrect() throws Exception {
+        assertEquals(mResultBundle, run());
+    }
+
+    @Test
+    public void bundleIDownloadedIfItAlreadyExistsButItsEmpty() throws Exception {
+        createExpectedResultDirectory();
+
+        run();
+
+        verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
+    }
+
+    @Test
+    public void bundleIsNotDownloadedIfItAlreadyExists() throws Exception {
+        createExpectedResultDirectoryWithFiles();
+
+        run();
+
+        verifyBundleIsNotUnarchived();
+        verifyArchiveIsNotDownloaded();
+    }
+
+    @Test
+    public void bundleIsReturnedIfItAlreadyExists() throws Exception {
+        verifyResult(createExpectedResultDirectoryWithFiles(), run());
+    }
+
+    @Test
+    public void bundleIsCorrectIfManifestContainsNoFiles() throws Exception {
+        setManifestContainsFiles(false);
+
+        verifyResult(
+                new ZincBundle(expectedResultDirectory(),
+                        mBundleID,
+                        mVersion),
+                run());
+    }
+
+    @Test
+    public void bundleFolderIsEmptyIfManifestContainsNoFiles() throws Exception {
+        setManifestContainsFiles(false);
+
+        final ZincBundle result = run();
+
+        assertTrue(result.exists());
+        assertEquals(0, result.listFiles().length);
+    }
+
+    @Test
+    public void nothingIsDownloadedIfManifestContainsNoFiles() throws Exception {
+        setManifestContainsFiles(false);
+
+        run();
+
+        verifyArchiveIsNotDownloaded();
+    }
+
+    @Test
+    public void archiveIsNotDownloadedIfItDoesntExist() throws Exception {
+        setManifestArchiveExists(false);
+
+        run();
+
+        verifyArchiveIsNotDownloaded();
+    }
+
+    @Test
+    public void fileIsDownloadedIfThereIsNoArchive() throws Exception {
+        final File expectedResultDirectory = expectedResultDirectory();
+
+        setManifestArchiveExists(false);
+
+        run();
+
+        verify(mJobFactory).downloadFile(eq(mObjectURL), eq(expectedResultDirectory), eq(mRepoFolder), eq(mSingleFilename), eq(false), anyString());
+    }
+
+    @Test
+    public void bundleIsCorrectIfOnlyOneFileIsDownloaded() throws Exception {
+        setManifestArchiveExists(false);
+
+        verifyResult(mDownloadedFile.getParentFile(), run());
+    }
+
+    private File createExpectedResultDirectory() throws IOException {
+        final File file = expectedResultDirectory();
+
+        assert file.getParentFile().exists() || file.mkdirs();
+        assert file.exists() || file.createNewFile();
+
+        assert file.exists();
+
+        return file;
+    }
+
+    private File createExpectedResultDirectoryWithFiles() throws IOException {
+        final File folder = createExpectedResultDirectory();
+
+        TestUtils.createRandomFileInFolder(folder);
+
+        return folder;
+    }
+
+    private File expectedResultDirectory() {
+        return new File(
+                mRepoFolder,
+                PathHelper.getLocalBundleFolder(mBundleID, mVersion, mFlavorName));
+    }
+
+    private void setManifestContainsFiles(final boolean containsFiles) {
+        when(mZincManifest.containsFiles(mFlavorName)).thenReturn(containsFiles);
+    }
+
+    private void setManifestArchiveExists(final boolean exists) {
+        when(mZincManifest.archiveExists(mFlavorName)).thenReturn(exists);
+    }
+
+    private void verifyBundleIsNotUnarchived() {
+        verify(mJobFactory, times(0)).unarchiveBundle(any(ZincBundle.class), any(ZincCloneBundleRequest.class), any(ZincManifest.class));
+    }
+
+    private void verifyArchiveIsNotDownloaded() {
+        verify(mJobFactory, times(0)).downloadBundle(any(ZincCloneBundleRequest.class), anyCatalogFuture());
+    }
+
+    private void verifyResult(final File directory, final ZincBundle result) {
+        assertEquals(directory.getAbsolutePath(), result.getAbsolutePath());
+        assertEquals(mBundleID, result.getBundleID());
+        assertEquals(mVersion, result.getVersion());
+    }
+
+    private static Future<ZincCatalog> anyCatalogFuture() {
+        return Matchers.any();
+    }
+
+    private ZincBundle run() throws Exception {
+        return job.call();
+    }
+}

--- a/src/test/java/com/mindsnacks/zinc/repo/ZincRepoBaseTest.java
+++ b/src/test/java/com/mindsnacks/zinc/repo/ZincRepoBaseTest.java
@@ -3,6 +3,7 @@ package com.mindsnacks.zinc.repo;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.mindsnacks.zinc.classes.data.ZincCatalogsCache;
+import com.mindsnacks.zinc.classes.data.ZincManifestsCache;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
 import com.mindsnacks.zinc.classes.ZincRepo;
 import com.mindsnacks.zinc.classes.ZincRepoIndexWriter;
@@ -33,6 +34,7 @@ public abstract class ZincRepoBaseTest extends ZincBaseTest {
 
     @Mock protected PriorityJobQueue<ZincCloneBundleRequest, ZincBundle> mQueue;
     @Mock protected ZincCatalogsCache mCatalogsCache;
+    @Mock protected ZincManifestsCache mManifestsCache;
 
     protected Gson mGson;
     @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
@@ -46,7 +48,7 @@ public abstract class ZincRepoBaseTest extends ZincBaseTest {
 
     protected void initializeRepo() {
         mIndexWriter = newRepoIndexWriter();
-        mRepo = new ZincRepo(mQueue, rootFolder.getRoot().toURI(), mIndexWriter, mCatalogsCache, mFlavorName);
+        mRepo = new ZincRepo(mQueue, rootFolder.getRoot().toURI(), mIndexWriter, mCatalogsCache, mManifestsCache, mFlavorName);
     }
 
     protected ZincRepoIndexWriter newRepoIndexWriter() {

--- a/src/test/java/com/mindsnacks/zinc/repo/ZincRepoInitializationTest.java
+++ b/src/test/java/com/mindsnacks/zinc/repo/ZincRepoInitializationTest.java
@@ -80,10 +80,11 @@ public class ZincRepoInitializationTest extends ZincRepoBaseTest {
     }
 
     @Test
-    public void clearCachedCatalogs() throws Exception {
-        mRepo.clearCachedCatalogs();
+    public void clearCachedCatalogsAndManifests() throws Exception {
+        mRepo.clearCachedCatalogsAndManifests();
 
         verify(mCatalogsCache).clearCachedCatalogs();
+        verify(mManifestsCache).clearCachedManifests();
     }
 
     private void writeSourceURLsToIndexFile(final List<SourceURL> newSourceURL) throws IOException {


### PR DESCRIPTION
### Description of the problem
For some strange reason, bundles might get corrupted after downloading. Take a look at [this issue](https://fabric.io/mindsnacks2/android/apps/com.wonder/issues/557f4a8ff505b5ccf02648a5/sessions/558c78da006c000115e42e25f648bf04) for more details. The real problem is, since the actual file exists, it will not try to re-download, leading to an **infinite crash loop**. Only way to fix it is uninstalling + reinstalling or with a new version of the Android app. This leads to users :rage2:

### Solution
Now, when we track bundles and we check if we need to download it or not, we do not only check for file existence. We actually check the integrity of the files, comparing them with the expected SHA-1 hashes present in the different `manifest.json`. If something is wrong, we simply delete the corrupted bundle and redownload it.

### Changes
- No more Java 6
- Introduction of  the class `ZincManifests` which implements the interface `ZincManifestCache`. Before, we were only using manifests once, now we store them locally so that we can check the integrity of the bundles later. This process is done by the class `BundleIntegrityVerifier`.
- Additionally, I added an extra check. What if the file that is corrupted is the actual `manifest.json`? We are also now checking for inexistent *or* invalid JSON manifests. The same way, I added this extra check for `catalog.json` in the `ZincCatalogsCache`. **These steps are very important, and will save us from many headaches and complains.**
- The method `clearCachedCatalogs` in the `ZincRepo` class, which was used to delete all the cached catalogs, is now transformed to `clearCachedCatalogsAndManifests`. Pegasus will need to update this call. That's the only interface change.
 
### TODO
- [ ] A bund of unwritten tests that were tested manually using Pegasus and adb

