### PR TITLE
[FINAL] Cleaning untracked bundles

### DIFF
--- a/src/main/java/com/mindsnacks/zinc/classes/Repo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/Repo.java
@@ -28,5 +28,5 @@ public interface Repo {
     /**
      * Must be called before calling start.
      */
-    void clearCachedCatalogsAndManifests();
+    void clearCachedCatalogs();
 }

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
@@ -110,9 +110,8 @@ public class ZincRepo implements Repo {
     }
 
     @Override
-    public void clearCachedCatalogsAndManifests() {
+    public void clearCachedCatalogs() {
         mCatalogsCache.clearCachedCatalogs();
-        mManifestsCache.clearCachedManifests();
     }
 
     @Override

--- a/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/PathHelper.java
@@ -16,18 +16,19 @@ public class PathHelper {
     private static final String MANIFESTS_FOLDER = "manifests";
     private static final String MANIFESTS_FORMAT = "json";
 
+    public static final String VERSION_SEPARATOR = "-";
     public static final String FLAVOR_SEPARATOR = "~";
 
     public static String getLocalDownloadFolder(final BundleID bundleID, final int version, final String flavorName) {
-        return String.format("%s/%s-%d%s%s", DOWNLOADS_FOLDER, bundleID, version, FLAVOR_SEPARATOR, flavorName);
+        return String.format("%s/%s%s%d%s%s", DOWNLOADS_FOLDER, bundleID, VERSION_SEPARATOR, version, FLAVOR_SEPARATOR, flavorName);
     }
 
     public static String getLocalBundleFolder(final BundleID bundleID, final int version, final String flavorName) {
-        return String.format("%s/%s-%d%s%s", BUNDLES_FOLDER, bundleID, version, FLAVOR_SEPARATOR, flavorName);
+        return String.format("%s/%s%s%d%s%s", BUNDLES_FOLDER, bundleID, VERSION_SEPARATOR, version, FLAVOR_SEPARATOR, flavorName);
     }
 
     public static String getLocalTemporaryBundleFolder(final BundleID bundleID, final int version, final String flavorName) {
-        return String.format("%s/%s-%d%s%s", TEMPORARY_BUNDLES_FOLDER, bundleID, version, FLAVOR_SEPARATOR, flavorName);
+        return String.format("%s/%s%s%d%s%s", TEMPORARY_BUNDLES_FOLDER, bundleID, VERSION_SEPARATOR, version, FLAVOR_SEPARATOR, flavorName);
     }
 
     public static String getLocalTemporaryDownloadFolder(final String name) {
@@ -39,7 +40,7 @@ public class PathHelper {
     }
 
     public static String getLocalManifestFilePath(final String catalogID, final String manifestID) {
-        return String.format("%s%s/%s.%s", getManifestsFolder(), catalogID, manifestID, MANIFESTS_FORMAT);
+        return String.format("%s%s.%s", getManifestsFolder(catalogID), manifestID, MANIFESTS_FORMAT);
     }
 
     public static String getCatalogsFolder() {
@@ -50,4 +51,26 @@ public class PathHelper {
         return String.format("%s/", MANIFESTS_FOLDER);
     }
 
+    public static String getBundlesFolder() { return String.format("%s/", BUNDLES_FOLDER);  }
+
+    public static String getManifestsFolder(final String catalogID) { return String.format("%s%s/", getManifestsFolder(), catalogID); }
+
+    public static String getManifestID(final String bundleName,
+                                       final int version) {
+        return String.format("%s%s%d", bundleName, VERSION_SEPARATOR, version);
+    }
+
+    public static String getBundleName(final String manifestFilename) {
+        return manifestFilename.substring(0, manifestFilename.lastIndexOf(VERSION_SEPARATOR));
+    }
+
+    public static int getBundleVersion(final String manifestFilename) {
+        return Integer.parseInt(manifestFilename.substring(manifestFilename.lastIndexOf(VERSION_SEPARATOR) + 1,
+                                                           manifestFilename.lastIndexOf(MANIFESTS_FORMAT) - 1));
+    }
+
+    public static String getBundleID(final String bundleFolder) {
+        String bundleFilenameWithoutFlavor = bundleFolder.substring(0, bundleFolder.lastIndexOf(FLAVOR_SEPARATOR));
+        return bundleFilenameWithoutFlavor.substring(0, bundleFilenameWithoutFlavor.lastIndexOf(VERSION_SEPARATOR));
+    }
 }

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincManifests.java
@@ -47,7 +47,7 @@ public class ZincManifests implements ZincManifestsCache {
     public synchronized Future<ZincManifest> getManifest(final SourceURL sourceURL,
                                                          final String bundleName,
                                                          final int version) {
-        String manifestID = getManifestID(bundleName, version);
+        String manifestID = PathHelper.getManifestID(bundleName, version);
 
         if (!mFutures.containsKey(manifestID)) {
             ListenableFuture<ZincManifest> result;
@@ -84,7 +84,7 @@ public class ZincManifests implements ZincManifestsCache {
                                                                          final String bundleName,
                                                                          final int version,
                                                                          final File manifestFile) {
-        final String manifestID = getManifestID(bundleName, version);
+        final String manifestID = PathHelper.getManifestID(bundleName, version);
         final ListenableFuture<ZincManifest> originalFuture = mFutures.get(manifestID);
         final ListenableFuture<ZincManifest> result = mDownloadExecutorService.submit(mJobFactory.downloadManifest(sourceURL, bundleName, version));
 
@@ -131,11 +131,6 @@ public class ZincManifests implements ZincManifestsCache {
 
     public File getManifestFile(final String catalogID, final String manifestID) {
         return new File(mRoot, PathHelper.getLocalManifestFilePath(catalogID, manifestID));
-    }
-
-    private String getManifestID(final String bundleName,
-                                 final int version) {
-        return String.format("%s-%d", bundleName, version);
     }
 
     private ZincManifest readManifestFile(final File manifestFile) throws FileNotFoundException {

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincUntrackedBundlesCleaner.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincUntrackedBundlesCleaner.java
@@ -1,0 +1,50 @@
+package com.mindsnacks.zinc.classes.data;
+
+import com.mindsnacks.zinc.classes.fileutils.FileHelper;
+
+import java.io.File;
+
+/**
+ * Created by Miguel Carranza on 7/2/15.
+ */
+public class ZincUntrackedBundlesCleaner {
+    private final FileHelper mFileHelper;
+
+    public ZincUntrackedBundlesCleaner(final FileHelper fileHelper) {
+        mFileHelper = fileHelper;
+    }
+
+    public void cleanUntrackedBundles(final File repoFolder,
+                                      final BundleID bundleID,
+                                      final int currentVersion) {
+        final File bundlesFolder = new File(repoFolder, PathHelper.getBundlesFolder());
+        final File manifestsFolder = new File(repoFolder, PathHelper.getManifestsFolder(bundleID.getCatalogID()));
+
+        cleanBundles(bundlesFolder, bundleID.toString());
+        cleanManifests(manifestsFolder, bundleID.getBundleName(), currentVersion);
+    }
+
+    private void cleanBundles(final File bundlesFolder,
+                              final String bundleID) {
+        if (bundlesFolder.exists()) {
+            for (File bundleFolder : bundlesFolder.listFiles()) {
+                if (PathHelper.getBundleID(bundleFolder.getName()).equals(bundleID)) {
+                    mFileHelper.removeDirectory(bundleFolder);
+                }
+            }
+        }
+    }
+
+    private void cleanManifests(final File manifestsFolder,
+                                final String bundleName,
+                                final int currentVersion) {
+        if (manifestsFolder.exists()) {
+            for (File manifestFile : manifestsFolder.listFiles()) {
+                if (PathHelper.getBundleName(manifestFile.getName()).equals(bundleName) &&
+                        PathHelper.getBundleVersion(manifestFile.getName()) != currentVersion) {
+                    mFileHelper.removeFile(manifestFile);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincDownloader.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincDownloader.java
@@ -58,7 +58,10 @@ public class ZincDownloader implements ZincJobFactory {
 
     @Override
     public Callable<ZincBundle> cloneBundle(final ZincCloneBundleRequest request, final Future<ZincCatalog> catalogFuture, final ZincManifestsCache manifests) {
-        return new ZincCloneBundleJob(request, this, catalogFuture, manifests);
+        FileHelper fileHelper = new FileHelper(mGson, new HashUtil());
+        ZincUntrackedBundlesCleaner bundlesCleaner = new ZincUntrackedBundlesCleaner(fileHelper);
+
+        return new ZincCloneBundleJob(request, this, catalogFuture, manifests, bundlesCleaner);
     }
 
     @Override

--- a/src/test/java/com/mindsnacks/zinc/data/PathHelperTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/PathHelperTest.java
@@ -5,11 +5,12 @@ import com.mindsnacks.zinc.classes.data.PathHelper;
 import com.mindsnacks.zinc.utils.ZincBaseTest;
 import org.junit.Test;
 
+import java.nio.file.Path;
+
 import static com.mindsnacks.zinc.utils.TestFactory.randomInt;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * User: NachoSoto
@@ -96,5 +97,36 @@ public class PathHelperTest extends ZincBaseTest {
     @Test
     public void manifestsFolder() throws Exception {
         assertTrue(PathHelper.getManifestsFolder().endsWith("/"));
+    }
+
+    @Test
+    public void manifestsFolderWithParams() throws Exception {
+        assertTrue(PathHelper.getManifestsFolder("meh").endsWith("/"));
+    }
+
+    @Test
+    public void getBundleName() {
+        final String bundleName = "a-simple-random_Bundle-name";
+        final String manifestFilename = String.format("%s.json", PathHelper.getManifestID(bundleName, 213));
+
+        assertEquals(bundleName, PathHelper.getBundleName(manifestFilename));
+    }
+
+    @Test
+    public void getBundleVersion() {
+        final String bundleName = "a-simple-random_Bundle-name";
+        final int version = 4245;
+        final String manifestFilename = String.format("%s.json", PathHelper.getManifestID(bundleName, version));
+
+        assertEquals(version, PathHelper.getBundleVersion(manifestFilename));
+    }
+
+    @Test
+    public void getBundleID() {
+        final BundleID bundleID = new BundleID("com.wonder.content3.sat-trol");
+        final String bundleFolder = PathHelper.getLocalBundleFolder(bundleID, 4, "3x-Android");
+        final String bundleFolderName = bundleFolder.substring(bundleFolder.indexOf("/") + 1);
+
+        assertEquals(bundleID.toString(), PathHelper.getBundleID(bundleFolderName));
     }
 }

--- a/src/test/java/com/mindsnacks/zinc/data/ZincUntrackedBundlesCleanerTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/ZincUntrackedBundlesCleanerTest.java
@@ -1,0 +1,115 @@
+package com.mindsnacks.zinc.data;
+
+import com.mindsnacks.zinc.classes.data.BundleID;
+import com.mindsnacks.zinc.classes.data.PathHelper;
+import com.mindsnacks.zinc.classes.data.ZincUntrackedBundlesCleaner;
+import com.mindsnacks.zinc.classes.fileutils.FileHelper;
+import com.mindsnacks.zinc.utils.TestUtils;
+import com.mindsnacks.zinc.utils.ZincBaseTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+import java.io.File;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Created by Miguel Carranza on 7/2/15.
+ */
+public class ZincUntrackedBundlesCleanerTest extends ZincBaseTest {
+    @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
+    @Mock private FileHelper mFileHelper;
+    private File mManifestsFolder;
+    private final int mVersion = 1245;
+
+    private final BundleID mBundleID = new BundleID("com.wonder.content.sat-public_speaking");
+    private File mBundle1, mBundle2, mBundle3, mManifest1, mManifest2, mManifest3;
+    private ZincUntrackedBundlesCleaner mBundlesCleaner;
+
+    @Before
+    public void setUp() {
+        mBundlesCleaner = new ZincUntrackedBundlesCleaner(mFileHelper);
+    }
+
+    @Test
+    public void cleanUntrackedBundlesCleansBundles() throws Exception {
+        createZincBundles();
+
+        assertTrue(mBundle1.exists());
+        assertTrue(mBundle2.exists());
+        assertTrue(mBundle3.exists());
+
+        mBundlesCleaner.cleanUntrackedBundles(rootFolder.getRoot(),
+                                              mBundleID,
+                                              mVersion);
+
+        verify(mFileHelper, times(1)).removeDirectory(eq(mBundle1));
+        verify(mFileHelper, times(1)).removeDirectory(eq(mBundle2));
+        verify(mFileHelper, times(0)).removeDirectory(eq(mBundle3));
+    }
+
+    @Test
+    public void cleanUntrackedBundlesCleansManifests() throws Exception {
+        createZincManifests();
+
+        assertTrue(mManifest1.exists());
+        assertTrue(mManifest2.exists());
+        assertTrue(mManifest3.exists());
+
+        mBundlesCleaner.cleanUntrackedBundles(rootFolder.getRoot(),
+                mBundleID,
+                1245);
+
+        verify(mFileHelper, times(1)).removeFile(eq(mManifest1));
+        verify(mFileHelper, times(1)).removeFile(eq(mManifest2));
+        verify(mFileHelper, times(0)).removeFile(eq(mManifest3));
+    }
+
+    @Test
+    public void cleanUntrackedBundlesDoesNotThrowWhenFoldersDoNotExist() {
+        mBundlesCleaner.cleanUntrackedBundles(rootFolder.getRoot(),
+                                              mBundleID,
+                                              mVersion);
+    }
+
+    private void createZincBundles() throws Exception {
+        String  localBundleFolder1 = PathHelper.getLocalBundleFolder(mBundleID, 23, "3xiOS"),
+                localBundleFolder2 = PathHelper.getLocalBundleFolder(mBundleID, 1323, "3xAndroid"),
+                localBundleFolder3 = PathHelper.getLocalBundleFolder(new BundleID("com.wonder.content.sat-public_speaking2"), 23, "3xiOS");
+
+        mBundle1 = new File(rootFolder.getRoot(), localBundleFolder1);
+        mBundle2 = new File(rootFolder.getRoot(), localBundleFolder2);
+        mBundle3 = new File(rootFolder.getRoot(), localBundleFolder3);
+
+        mBundle1.mkdirs();
+        mBundle2.mkdirs();
+        mBundle3.mkdirs();
+    }
+
+    private void createZincManifests() throws Exception {
+        mManifestsFolder = new File(rootFolder.getRoot(),
+                                    PathHelper.getManifestsFolder(mBundleID.getCatalogID()));
+        mManifestsFolder.mkdirs();
+
+        mManifest1 = new File(mManifestsFolder,
+                              PathHelper.getManifestID(mBundleID.getBundleName(), mVersion + 1) + ".json");
+        mManifest2 = new File(mManifestsFolder,
+                              PathHelper.getManifestID(mBundleID.getBundleName(), mVersion + 2) + ".json");
+        mManifest3 = new File(mManifestsFolder,
+                              PathHelper.getManifestID(mBundleID.getBundleName(), mVersion)  + ".json");
+
+        TestUtils.writeToFile(mManifest1,
+                              "whatever");
+        TestUtils.writeToFile(mManifest2,
+                              "whatever");
+        TestUtils.writeToFile(mManifest3,
+                              "whatever");
+    }
+}

--- a/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
+++ b/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
@@ -100,6 +100,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
     public void bundleIsDownloaded() throws Exception {
         run();
 
+        verifyUntrackedBundlesAreCleaned();
         verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
     }
 
@@ -114,6 +115,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
     public void bundleIsUnarchived() throws Exception {
         run();
 
+        verifyUntrackedBundlesAreCleaned();
         verify(mJobFactory).unarchiveBundle(eq(mDownloadedBundle), eq(mRequest), eq(mZincManifest));
     }
 
@@ -128,6 +130,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
 
         run();
 
+        verifyUntrackedBundlesAreCleaned();
         verify(mJobFactory).downloadBundle(eq(mRequest), eq(mZincCatalogFuture));
     }
 
@@ -137,6 +140,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
 
         run();
 
+        verifyUntrackedBundlesAreNotCleaned();
         verifyBundleIsNotUnarchived();
         verifyArchiveIsNotDownloaded();
     }
@@ -248,6 +252,14 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
         assertEquals(directory.getAbsolutePath(), result.getAbsolutePath());
         assertEquals(mBundleID, result.getBundleID());
         assertEquals(mVersion, result.getVersion());
+    }
+
+    private void verifyUntrackedBundlesAreCleaned() {
+        verify(mBundlesCleaner, times(1)).cleanUntrackedBundles(any(File.class), any(BundleID.class), any(Integer.class));
+    }
+
+    private void verifyUntrackedBundlesAreNotCleaned() {
+        verify(mBundlesCleaner, times(0)).cleanUntrackedBundles(any(File.class), any(BundleID.class), any(Integer.class));
     }
 
     private static Future<ZincCatalog> anyCatalogFuture() {

--- a/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
+++ b/src/test/java/com/mindsnacks/zinc/jobs/ZincCloneBundleJobTest.java
@@ -46,6 +46,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
     @Mock private ZincManifest mZincManifest;
     @Mock private ZincManifest.FileInfo mFileWithFlavor;
     @Mock private ZincManifests mZincManifests;
+    @Mock private ZincUntrackedBundlesCleaner mBundlesCleaner;
     private URL mObjectURL;
 
     private final String mDistribution = "master";
@@ -68,7 +69,7 @@ public class ZincCloneBundleJobTest extends ZincBaseTest {
         mObjectURL = new URL("https://www.nsa.gov");
 
         mRequest = new ZincCloneBundleRequest(mSourceURL, mBundleID, mDistribution, mFlavorName, mRepoFolder);
-        job = new ZincCloneBundleJob(mRequest, mJobFactory, mZincCatalogFuture, mZincManifests);
+        job = new ZincCloneBundleJob(mRequest, mJobFactory, mZincCatalogFuture, mZincManifests, mBundlesCleaner);
 
         when(mJobFactory.downloadBundle(eq(mRequest), eq(mZincCatalogFuture))).thenReturn(mDownloadBundleJob);
         when(mJobFactory.downloadManifest(eq(mSourceURL), eq(mBundleName), eq(mVersion))).thenReturn(mZincManifestJob);

--- a/src/test/java/com/mindsnacks/zinc/repo/ZincRepoInitializationTest.java
+++ b/src/test/java/com/mindsnacks/zinc/repo/ZincRepoInitializationTest.java
@@ -80,11 +80,10 @@ public class ZincRepoInitializationTest extends ZincRepoBaseTest {
     }
 
     @Test
-    public void clearCachedCatalogsAndManifests() throws Exception {
-        mRepo.clearCachedCatalogsAndManifests();
+    public void clearCachedCatalogs() throws Exception {
+        mRepo.clearCachedCatalogs();
 
         verify(mCatalogsCache).clearCachedCatalogs();
-        verify(mManifestsCache).clearCachedManifests();
     }
 
     private void writeSourceURLsToIndexFile(final List<SourceURL> newSourceURL) throws IOException {


### PR DESCRIPTION
Fixes [this](https://github.com/mindsnacks/JavaZinc/issues/30) and saves at a lot of :moneybag: :moneybag: 

Bundles are deleted lazily, only when a new version of the bundle is going to be downloaded.