### PR TITLE
[FINAL] Removing temporary folder just in case

### DIFF
--- a/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincUnarchiveBundleJob.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincUnarchiveBundleJob.java
@@ -39,6 +39,7 @@ public class ZincUnarchiveBundleJob extends ZincJob<ZincBundle> {
         final File temporaryFolder = getTemporaryBundleFolder(bundleID),
                    resultFolder = getBundleFolder(bundleID);
 
+        mFileHelper.removeDirectory(temporaryFolder);
         unarchiveBundle(mDownloadedBundle, temporaryFolder, mManifest);
 
         cleanUpDownloadedFolder();


### PR DESCRIPTION
### Overview
So... Pegasus 2.1 went out, and though the number of invalid assets crashes was drastically reduced, unfortunately, **it still happens**. 

It happens less frequently, because now **it is not blocking** as it used to be, by the time you reopen the app it will try to re-downloaded corrupted assets.

After putting a lot of effort on debugging, and going step by step, I can honestly only think of a single point of failure for this system, which is addressed in this pull request.

### Solution
Anything outside of the *happy path* happening after zinc knows it has to download a bundle (`downloadBundle` && `unarchiveBundle`) will throw an Exception. If that's the case, Pegasus will show a *Check your connectivity* dialog. It's not ideal, but it will trigger the re-download re-unarchive flow.

There are only 2 places that do not throw exceptions:
* After bundle is unarchived, we check hash (if wrong, exception). Then we **move** this temporary folder to the final one. I thought that could be it (we do not check the content of the final folder). However, after doing some research, I realized that [*we actually do check it*](https://github.com/mindsnacks/JavaZinc/blob/master/src/main/java/com/mindsnacks/zinc/classes/jobs/ZincUnarchiveBundleJob.java#L97). If renaming fails (which should be atomic in this platform, btw), we throw an exception. So **TL;DR not here**.

* Second place. If the temporary file exists for some reason (maybe it was not cleared properly! or the **uncompression failed**, which is actually a pretty common scenario!), this file [**is not overwritten**](https://github.com/mindsnacks/JavaZinc/blob/master/src/main/java/com/mindsnacks/zinc/classes/fileutils/FileHelper.java#L34). Therefore, if it was corrupt, it would remain corrupt!. Solution ---> Deleting temporary folder **before unarchiving**. 

### What if?
This is the most I can do without more data. Hopefully, this will make it. I really does make sense to me. 

It is already working way better than it used to be. But if this does not fix it 100%, I will probably need to activate Zinc logs and try to find out if something else is happening.