### PR TITLE
[FINAL] Added stop tracking bundles functionality

### DIFF
--- a/src/main/java/com/mindsnacks/zinc/classes/Repo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/Repo.java
@@ -21,6 +21,8 @@ public interface Repo {
 
     void startTrackingBundles(List<BundleID> bundleIDs, String distribution);
 
+    void stopTrackingBundles(Set<BundleID> bundleIDs, String distribution);
+
     Future<ZincBundle> getBundle(BundleID bundleID);
 
     Set<BundleID> getTrackedBundleIDs();

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
@@ -8,8 +8,11 @@ import com.mindsnacks.zinc.classes.data.ZincCatalogsCache;
 import com.mindsnacks.zinc.classes.data.ZincCloneBundleRequest;
 import com.mindsnacks.zinc.classes.data.ZincManifestsCache;
 import com.mindsnacks.zinc.classes.data.ZincRepoIndex;
+import com.mindsnacks.zinc.classes.data.ZincUntrackedBundlesCleaner;
 import com.mindsnacks.zinc.classes.downloads.PriorityJobQueue;
+import com.mindsnacks.zinc.classes.fileutils.FileHelper;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
+
 import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
@@ -27,6 +30,7 @@ public class ZincRepo implements Repo {
     private final ZincRepoIndexWriter mIndexWriter;
     private final ZincCatalogsCache mCatalogsCache;
     private final ZincManifestsCache mManifestsCache;
+    private final FileHelper mFileHelper;
     private final String mFlavorName;
 
     private final File mRoot;
@@ -42,10 +46,12 @@ public class ZincRepo implements Repo {
                     final ZincRepoIndexWriter repoIndexWriter,
                     final ZincCatalogsCache catalogsCache,
                     final ZincManifestsCache manifestsCache,
+                    final FileHelper fileHelper,
                     final String flavorName) {
         mQueue = queue;
         mCatalogsCache = catalogsCache;
         mManifestsCache = manifestsCache;
+        mFileHelper = fileHelper;
         mFlavorName = flavorName;
         mRoot = new File(root);
         mIndexWriter = repoIndexWriter;
@@ -86,6 +92,30 @@ public class ZincRepo implements Repo {
         }
 
         if (newTrackedBundles) {
+            mIndexWriter.saveIndex();
+        }
+    }
+
+    @Override
+    public void stopTrackingBundles(final Set<BundleID> bundleIDs, final String distribution) {
+        final ZincRepoIndex index = mIndexWriter.getIndex();
+        boolean bundlesStoppedTracking = false;
+
+        ZincUntrackedBundlesCleaner bundlesCleaner = new ZincUntrackedBundlesCleaner(mFileHelper);
+
+        for (final BundleID bundleID : bundleIDs) {
+            boolean stoppedTrackingBundle = index.stopTrackingBundle(bundleID, distribution);
+            bundlesStoppedTracking |= stoppedTrackingBundle;
+            if (stoppedTrackingBundle && mBundles.containsKey(bundleID)) {
+                ZincCloneBundleRequest zincCloneBundleRequest = mBundles.get(bundleID);
+                mBundles.remove(bundleID);
+                mQueue.get(zincCloneBundleRequest).cancel(true);
+                mQueue.remove(zincCloneBundleRequest);
+                bundlesCleaner.cleanBundle(mRoot, bundleID);
+            }
+        }
+
+        if (bundlesStoppedTracking) {
             mIndexWriter.saveIndex();
         }
     }

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepo.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 /**
  * User: NachoSoto
@@ -109,7 +110,10 @@ public class ZincRepo implements Repo {
             if (stoppedTrackingBundle && mBundles.containsKey(bundleID)) {
                 ZincCloneBundleRequest zincCloneBundleRequest = mBundles.get(bundleID);
                 mBundles.remove(bundleID);
-                mQueue.get(zincCloneBundleRequest).cancel(true);
+                Future<ZincBundle> zincBundleFuture = mQueue.get(zincCloneBundleRequest);
+                if (zincBundleFuture != null) {
+                    zincBundleFuture.cancel(true);
+                }
                 mQueue.remove(zincCloneBundleRequest);
                 bundlesCleaner.cleanBundle(mRoot, bundleID);
             }

--- a/src/main/java/com/mindsnacks/zinc/classes/ZincRepoFactory.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/ZincRepoFactory.java
@@ -29,6 +29,7 @@ public final class ZincRepoFactory {
                            final int bundleCloneConcurrency,
                            final PriorityCalculator<BundleID> priorityCalculator) {
         final Gson gson = createGson();
+        final FileHelper fileHelper = new FileHelper(gson, new HashUtil());
         final ZincJobFactory jobFactory = createJobFactory(gson);
         final ZincRepoIndexWriter indexWriter = createRepoIndexWriter(root, gson);
 
@@ -43,7 +44,7 @@ public final class ZincRepoFactory {
                 new ZincBundleDownloader(jobFactory, catalogs, manifests),
                 createPriorityCalculator(priorityCalculator));
 
-        return new ZincRepo(queue, root.toURI(), indexWriter, catalogs, manifests, flavorName);
+        return new ZincRepo(queue, root.toURI(), indexWriter, catalogs, manifests, fileHelper, flavorName);
     }
 
     private ZincCatalogsCache createCatalogCache(final ZincJobFactory jobFactory,

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincRepoIndex.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincRepoIndex.java
@@ -50,6 +50,17 @@ public class ZincRepoIndex {
         }
     }
 
+    public boolean stopTrackingBundle(final BundleID bundleID, final String distribution) {
+        final String key = bundleID.toString();
+
+        if (mBundles.containsKey(key) && mBundles.get(key).getDistribution().equals(distribution)) {
+            mBundles.remove(key);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public TrackingInfo getTrackingInfo(final BundleID bundleID) throws BundleNotBeingTrackedException {
         final String key = bundleID.toString();
 

--- a/src/main/java/com/mindsnacks/zinc/classes/data/ZincUntrackedBundlesCleaner.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/data/ZincUntrackedBundlesCleaner.java
@@ -14,6 +14,15 @@ public class ZincUntrackedBundlesCleaner {
         mFileHelper = fileHelper;
     }
 
+    public void cleanBundle(final File repoFolder,
+                            final BundleID bundleID) {
+        final File bundlesFolder = new File(repoFolder, PathHelper.getBundlesFolder());
+        final File manifestsFolder = new File(repoFolder, PathHelper.getManifestsFolder(bundleID.getCatalogID()));
+
+        cleanBundles(bundlesFolder, bundleID.toString());
+        cleanAllManifests(manifestsFolder, bundleID.getBundleName());
+    }
+
     public void cleanUntrackedBundles(final File repoFolder,
                                       final BundleID bundleID,
                                       final int currentVersion) {
@@ -42,6 +51,17 @@ public class ZincUntrackedBundlesCleaner {
             for (File manifestFile : manifestsFolder.listFiles()) {
                 if (PathHelper.getBundleName(manifestFile.getName()).equals(bundleName) &&
                         PathHelper.getBundleVersion(manifestFile.getName()) != currentVersion) {
+                    mFileHelper.removeFile(manifestFile);
+                }
+            }
+        }
+    }
+
+    private void cleanAllManifests(final File manifestsFolder,
+                                   final String bundleName) {
+        if (manifestsFolder.exists()) {
+            for (File manifestFile : manifestsFolder.listFiles()) {
+                if (PathHelper.getBundleName(manifestFile.getName()).equals(bundleName)) {
                     mFileHelper.removeFile(manifestFile);
                 }
             }

--- a/src/main/java/com/mindsnacks/zinc/classes/downloads/PriorityJobQueue.java
+++ b/src/main/java/com/mindsnacks/zinc/classes/downloads/PriorityJobQueue.java
@@ -148,6 +148,14 @@ public class PriorityJobQueue<Input, Output> {
         addElementToQueue(element);
     }
 
+    public void remove(final Input element) throws JobNotFoundException {
+        checkServiceIsRunning(true, "Service should be running");
+        checkJobWasAlreadyAdded(element);
+        mAddedElements.remove(element);
+        mQueue.remove(element);
+        removeCachedFuture(element);
+    }
+
     private ListenableFuture<Output> findExistingFuture(final Input element) {
         mLock.lock();
 

--- a/src/test/java/com/mindsnacks/zinc/data/ZincRepoIndexTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/ZincRepoIndexTest.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertFalse;
 
 /**
  * User: NachoSoto
@@ -73,6 +75,35 @@ public class ZincRepoIndexTest extends ZincBaseTest {
 
         // verify
         assertEquals(new HashSet<BundleID>(Arrays.asList(bundleID1, bundleID2)), index.getTrackedBundleIDs());
+    }
+
+    @Test
+    public void stopTrackingBundle() throws Exception {
+        final BundleID bundleID1 = new BundleID("com.mindsnacks.games.swell"),
+                bundleID2 = new BundleID("com.mindsnacks.lessons.body-parts");
+
+        // run
+        index.trackBundle(bundleID1, "master");
+        index.trackBundle(bundleID2, "develop");
+
+        // verify
+        assertEquals(new HashSet<BundleID>(Arrays.asList(bundleID1, bundleID2)), index.getTrackedBundleIDs());
+
+        assertTrue(index.stopTrackingBundle(bundleID1, "master"));
+        assertTrue(index.stopTrackingBundle(bundleID2, "develop"));
+
+        assertEquals(new HashSet<BundleID>(), index.getTrackedBundleIDs());
+    }
+
+    @Test
+    public void stopTrackingNotTrackingBundleReturnsFalse() throws Exception {
+        final BundleID bundleID1 = new BundleID("com.mindsnacks.games.swell"),
+                bundleID2 = new BundleID("com.mindsnacks.lessons.body-parts");
+
+        index.trackBundle(bundleID1, "onedistribution");
+
+        assertFalse(index.stopTrackingBundle(bundleID1, "anotherdistribution"));
+        assertFalse(index.stopTrackingBundle(bundleID2, "onedistribution"));
     }
 
     @Test

--- a/src/test/java/com/mindsnacks/zinc/data/ZincUntrackedBundlesCleanerTest.java
+++ b/src/test/java/com/mindsnacks/zinc/data/ZincUntrackedBundlesCleanerTest.java
@@ -79,6 +79,36 @@ public class ZincUntrackedBundlesCleanerTest extends ZincBaseTest {
                                               mVersion);
     }
 
+    @Test
+    public void cleanBundleCleansBundles() throws Exception {
+        createZincBundles();
+
+        assertTrue(mBundle1.exists());
+        assertTrue(mBundle2.exists());
+        assertTrue(mBundle3.exists());
+
+        mBundlesCleaner.cleanBundle(rootFolder.getRoot(), mBundleID);
+
+        verify(mFileHelper, times(1)).removeDirectory(eq(mBundle1));
+        verify(mFileHelper, times(1)).removeDirectory(eq(mBundle2));
+        verify(mFileHelper, times(0)).removeDirectory(eq(mBundle3));
+    }
+
+    @Test
+    public void cleanBundleCleansAllManifests() throws Exception {
+        createZincManifests();
+
+        assertTrue(mManifest1.exists());
+        assertTrue(mManifest2.exists());
+        assertTrue(mManifest3.exists());
+
+        mBundlesCleaner.cleanBundle(rootFolder.getRoot(), mBundleID);
+
+        verify(mFileHelper, times(1)).removeFile(eq(mManifest1));
+        verify(mFileHelper, times(1)).removeFile(eq(mManifest2));
+        verify(mFileHelper, times(1)).removeFile(eq(mManifest3));
+    }
+
     private void createZincBundles() throws Exception {
         String  localBundleFolder1 = PathHelper.getLocalBundleFolder(mBundleID, 23, "3xiOS"),
                 localBundleFolder2 = PathHelper.getLocalBundleFolder(mBundleID, 1323, "3xAndroid"),

--- a/src/test/java/com/mindsnacks/zinc/downloads/PriorityJobQueueTest.java
+++ b/src/test/java/com/mindsnacks/zinc/downloads/PriorityJobQueueTest.java
@@ -298,6 +298,36 @@ public class PriorityJobQueueTest extends ZincBaseTest {
         queue.reAdd(data);
     }
 
+    @Test(expected = ZincRuntimeException.class)
+    public void removingElementWhenServiceIsStoppedThrows() throws Exception {
+        final TestData data = processAndAddRandomData();
+
+        queue.start();
+        queue.stop();
+
+        queue.remove(data);
+    }
+
+    @Test
+    public void removingDataDoesntThrow() throws Exception {
+        final TestData data = processAndAddRandomData();
+
+        queue.start();
+
+        queue.remove(data);
+    }
+
+    @Test(expected = PriorityJobQueue.JobNotFoundException.class)
+    public void afterRemovingDataCannotGetData() throws Exception {
+        final TestData data = processAndAddRandomData();
+
+        queue.start();
+
+        queue.remove(data);
+
+        queue.get(data);
+    }
+
     private TestData processAndAddRandomData() {
         return processAndAddData(TestData.randomTestData());
     }

--- a/src/test/java/com/mindsnacks/zinc/repo/ZincRepoBaseTest.java
+++ b/src/test/java/com/mindsnacks/zinc/repo/ZincRepoBaseTest.java
@@ -10,6 +10,7 @@ import com.mindsnacks.zinc.classes.ZincRepoIndexWriter;
 import com.mindsnacks.zinc.classes.data.ZincBundle;
 import com.mindsnacks.zinc.classes.data.ZincCloneBundleRequest;
 import com.mindsnacks.zinc.classes.data.ZincRepoIndex;
+import com.mindsnacks.zinc.classes.fileutils.FileHelper;
 import com.mindsnacks.zinc.exceptions.ZincRuntimeException;
 import com.mindsnacks.zinc.utils.TestUtils;
 import com.mindsnacks.zinc.utils.ZincBaseTest;
@@ -35,6 +36,7 @@ public abstract class ZincRepoBaseTest extends ZincBaseTest {
     @Mock protected PriorityJobQueue<ZincCloneBundleRequest, ZincBundle> mQueue;
     @Mock protected ZincCatalogsCache mCatalogsCache;
     @Mock protected ZincManifestsCache mManifestsCache;
+    @Mock protected FileHelper mFileHelper;
 
     protected Gson mGson;
     @Rule public final TemporaryFolder rootFolder = new TemporaryFolder();
@@ -48,7 +50,7 @@ public abstract class ZincRepoBaseTest extends ZincBaseTest {
 
     protected void initializeRepo() {
         mIndexWriter = newRepoIndexWriter();
-        mRepo = new ZincRepo(mQueue, rootFolder.getRoot().toURI(), mIndexWriter, mCatalogsCache, mManifestsCache, mFlavorName);
+        mRepo = new ZincRepo(mQueue, rootFolder.getRoot().toURI(), mIndexWriter, mCatalogsCache, mManifestsCache, mFileHelper, mFlavorName);
     }
 
     protected ZincRepoIndexWriter newRepoIndexWriter() {

--- a/src/test/java/com/mindsnacks/zinc/repo/ZincRepoJobsTest.java
+++ b/src/test/java/com/mindsnacks/zinc/repo/ZincRepoJobsTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
@@ -155,6 +156,29 @@ public class ZincRepoJobsTest extends ZincRepoBaseTest {
 
         // verify
         verifySaveIndex();
+    }
+
+    @Test
+    public void stopTrackingBundlesStopsTrackingThem() throws Exception {
+        mockGetTrackingInfo(mBundleID, mDistribution);
+        mockGetTrackingInfo(mAnotherBundleID, mDistribution);
+
+        when(mRepoIndex.stopTrackingBundle(mBundleID, mDistribution)).thenReturn(true);
+
+        // run
+        mRepo.startTrackingBundles(Arrays.asList(mBundleID, mAnotherBundleID), mDistribution);
+
+        // verify
+        verifyCloneBundle(mBundleID, mDistribution);
+        verifyCloneBundle(mAnotherBundleID, mDistribution);
+
+        Set<BundleID> bundlesToStop = new HashSet<>();
+        bundlesToStop.add(mBundleID);
+        mRepo.stopTrackingBundles(bundlesToStop, mDistribution);
+
+        verify(mRepoIndex, times(1)).stopTrackingBundle(eq(mBundleID), eq(mDistribution));
+        verify(mQueue, times(1)).remove(any(ZincCloneBundleRequest.class));
+        verify(mIndexWriter, times(2)).saveIndex();
     }
 
     @Test


### PR DESCRIPTION
New method in ZincRepo that should stop tracking any bundles and remove the bundles and manifests if they are already downloaded